### PR TITLE
Usage of configuration file in JSON format for the Sink connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1387,7 +1387,7 @@ To manually install Kafka Connect Lightstreamer Sink Connector to a local Conflu
 
 3. Edit the connector configuration properties file as detailed in the [Configuration Reference](#configuration-reference) section.
    
-   You may want to use the provided [`quickstart-lightstreamer-local.properties`](./kafka-connector-project/config/kafka-connect-config/connect-standalone-local.properties) file as starting pint. This file provides the set of pre-configured settings to feed Lightstreamer with stock market events, as already shown in the [installation instruction](#installation) for the Lightstreamer Kafka Connector.
+   You may want to use the provided [`quickstart-lightstreamer-local.properties`](./kafka-connector-project/config/kafka-connect-config/connect-standalone-local.properties) or ['quickstart-lightstreamer-local.json`](./kafka-connector-project/config/kafka-connect-config/connect-standalone-local.properties) files as starting pint. This file provides the set of pre-configured settings to feed Lightstreamer with stock market events, as already shown in the [installation instruction](#installation) for the Lightstreamer Kafka Connector.
 
 4. Launch the Lightstreamer Server instance already configured in the [Lightstreamer Setup](#lightstreamer-setup) section.
 

--- a/README.md
+++ b/README.md
@@ -1387,7 +1387,7 @@ To manually install Kafka Connect Lightstreamer Sink Connector to a local Conflu
 
 3. Edit the connector configuration properties file as detailed in the [Configuration Reference](#configuration-reference) section.
    
-   You may want to use the provided [`quickstart-lightstreamer-local.properties`](./kafka-connector-project/config/kafka-connect-config/connect-standalone-local.properties) or ['quickstart-lightstreamer-local.json`](./kafka-connector-project/config/kafka-connect-config/connect-standalone-local.properties) files as starting pint. This file provides the set of pre-configured settings to feed Lightstreamer with stock market events, as already shown in the [installation instruction](#installation) for the Lightstreamer Kafka Connector.
+   You may want to use the provided [`quickstart-lightstreamer-local.properties`](./kafka-connector-project/config/kafka-connect-config/quickstart-lightstreamer-local.properties) or [`quickstart-lightstreamer-local.json`](./kafka-connector-project/config/kafka-connect-config/connect-standalone-local.json) files as starting pint. This file provides the set of pre-configured settings to feed Lightstreamer with stock market events, as already shown in the [installation instruction](#installation) for the Lightstreamer Kafka Connector.
 
 4. Launch the Lightstreamer Server instance already configured in the [Lightstreamer Setup](#lightstreamer-setup) section.
 

--- a/README.md
+++ b/README.md
@@ -1387,7 +1387,7 @@ To manually install Kafka Connect Lightstreamer Sink Connector to a local Conflu
 
 3. Edit the connector configuration properties file as detailed in the [Configuration Reference](#configuration-reference) section.
    
-   You may want to use the provided [`quickstart-lightstreamer-local.properties`](./kafka-connector-project/config/kafka-connect-config/quickstart-lightstreamer-local.properties) or [`quickstart-lightstreamer-local.json`](./kafka-connector-project/config/kafka-connect-config/connect-standalone-local.json) files as starting pint. This file provides the set of pre-configured settings to feed Lightstreamer with stock market events, as already shown in the [installation instruction](#installation) for the Lightstreamer Kafka Connector.
+   You may want to use the provided [`quickstart-lightstreamer-local.properties`](./kafka-connector-project/config/kafka-connect-config/quickstart-lightstreamer-local.properties) or [`quickstart-lightstreamer-local.json`](./kafka-connector-project/config/kafka-connect-config/quickstart-lightstreamer-local.json) files as starting pint. This file provides the set of pre-configured settings to feed Lightstreamer with stock market events, as already shown in the [installation instruction](#installation) for the Lightstreamer Kafka Connector.
 
 4. Launch the Lightstreamer Server instance already configured in the [Lightstreamer Setup](#lightstreamer-setup) section.
 

--- a/examples/quickstart-kafka-connect/docker-compose.yml
+++ b/examples/quickstart-kafka-connect/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - connect-standalone
       - /config/connect-standalone-docker.properties
       - /config/quickstart-lightstreamer-docker.properties
+      # You may also use the provided json format:
+      #- /config/quickstart-lightstreamer-docker.json
     depends_on:
       - broker
       - lightstreamer

--- a/examples/quickstart-kafka-connect/docker-compose.yml
+++ b/examples/quickstart-kafka-connect/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - connect-standalone
       - /config/connect-standalone-docker.properties
       - /config/quickstart-lightstreamer-docker.properties
-      # You may also use the provided json format:
+      # You may also use the provided json file:
       #- /config/quickstart-lightstreamer-docker.json
     depends_on:
       - broker

--- a/kafka-connector-project/config/kafka-connect-config/quickstart-lightstreamer-docker.json
+++ b/kafka-connector-project/config/kafka-connect-config/quickstart-lightstreamer-docker.json
@@ -1,0 +1,12 @@
+{
+    "name": "lightstreamer-sink",
+    "connector.class": "com.lightstreamer.kafka.connect.LightstreamerSinkConnector",
+    "topics": "stocks",
+    "lightstreamer.server.proxy_adapter.address": "lightstreamer:6661",
+    "lightstreamer.server.proxy_adapter.socket.connection.setup.timeout.ms": 15000,
+    "lightstreamer.server.proxy_adapter.socket.connection.setup.max.retries": 5,
+    "lightstreamer.server.proxy_adapter.socket.connection.setup.retry.delay.ms": 15000,
+    "item.templates": "stock-template:stock-#{index=KEY}",
+    "topic.mappings": "stocks:item-template.stock-template",
+    "record.mapping": "timestamp:#{VALUE.timestamp},time:#{VALUE.time},stock_name:#{VALUE.name},last_price:#{VALUE.last_price},ask:#{VALUE.ask},ask_quantity:#{VALUE.ask_quantity},bid:#{VALUE.bid},bid_quantity:#{VALUE.bid_quantity},pct_change:#{VALUE.pct_change},min:#{VALUE.min},max:#{VALUE.max},ref_price:#{VALUE.ref_price},open_price:#{VALUE.open_price},item_status:#{VALUE.item_status},ts:#{TIMESTAMP},topic:#{TOPIC},offset:#{OFFSET},partition:#{PARTITION}"
+}

--- a/kafka-connector-project/config/kafka-connect-config/quickstart-lightstreamer-local.json
+++ b/kafka-connector-project/config/kafka-connect-config/quickstart-lightstreamer-local.json
@@ -1,0 +1,12 @@
+{
+    "name": "lightstreamer-sink",
+    "connector.class": "com.lightstreamer.kafka.connect.LightstreamerSinkConnector",
+    "topics": "stocks",
+    "lightstreamer.server.proxy_adapter.address": "localhost:6661",
+    "lightstreamer.server.proxy_adapter.socket.connection.setup.timeout.ms": 15000,
+    "lightstreamer.server.proxy_adapter.socket.connection.setup.max.retries": 5,
+    "lightstreamer.server.proxy_adapter.socket.connection.setup.retry.delay.ms": 15000,
+    "item.templates": "stock-template:stock-#{index=KEY}",
+    "topic.mappings": "stocks:item-template.stock-template",
+    "record.mapping": "timestamp:#{VALUE.timestamp},time:#{VALUE.time},stock_name:#{VALUE.name},last_price:#{VALUE.last_price},ask:#{VALUE.ask},ask_quantity:#{VALUE.ask_quantity},bid:#{VALUE.bid},bid_quantity:#{VALUE.bid_quantity},pct_change:#{VALUE.pct_change},min:#{VALUE.min},max:#{VALUE.max},ref_price:#{VALUE.ref_price},open_price:#{VALUE.open_price},item_status:#{VALUE.item_status},ts:#{TIMESTAMP},topic:#{TOPIC},offset:#{OFFSET},partition:#{PARTITION}"
+}


### PR DESCRIPTION
The README.md file explains how to use either the configuration properties file or the configuration JSON file to run the Sink connector.

Examples of JSON files have been provided under the [kafka-connector-project/config/kafka-connect-config](./kafka-connector-project/config/kafka-connect-config) folder.

The [examples/quickstart-kafka-connect/docker-compose.yml](./examples/quickstart-kafka-connect/docker-compose.yml) file mention how to reference the JSON configuration file.

In addition, the link to the [kafka-connector-project/config/kafka-connect-config/quickstart-lightstreamer-local.properties](./kafka-connector-project/config/kafka-connect-config/quickstart-lightstreamer-local.properties) has been fixed.