### PR TITLE
Add the etc folder to the Sink connector zip file

### DIFF
--- a/kafka-connector-project/kafka-connector/build.gradle
+++ b/kafka-connector-project/kafka-connector/build.gradle
@@ -110,7 +110,6 @@ distributions {
 
 			from (connectConfigDir) {
 				into "etc"
-				include "quickstart-lightstreamer.properties"
 			}
 
 			from ("src/connect/manifest.json.tpl") {


### PR DESCRIPTION
Add the `etc` folder to the Sink connector zip along with the example configuration files.