### PR TITLE
Fix broken links in the examples/quickstart-schema-registry directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [1.0.7] (Unreleased)
+
+**Improvements and Documentation**
+
+- Improved the [README.md](README.md) file. ([#18](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/18), [#20](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/20),
+[#21](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/21),
+[#22](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/22))  
+
+- Significantly reorganized the [examples](examples) folder. Specifically:
+
+  - Moved the quick start examples for specific vendors (Confluent, Redpanda, Aiven, and Axual) into dedicated subfolders under [examples/vendors](examples/vendors/). ([#20](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/20))
+
+  - Adjusted the script files to align with the updated layout of the examples folder. ([#20](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/20))
+
+  - Improved the `docker-compose.yml` and `README.md` files within the quick start folders. ([#20](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/20))
+
+  - Improved the `README.md` files within [examples/docker](examples/docker/) and [examples/docker-kafka-connect](examples/docker-kafka-connect/) folders. ([#20](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/20))
+
+  - Introduced a dedicated [README.md](examples/vendors/confluent/README.md) file for _Confluent Cloud_ along with further specific resources under [examples/vendors/confluent](examples/vendors/confluent/). ([#20](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/20), [#22](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/22))
+
+  - Added new resources to the [pictures](pictures) folder. ([#18](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/18), [#20](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/20), [#22](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/22))
+
+  - Added a new data adapter configuration named `QuickStartConfluentCloud` to the factory [adapters.xml](kafka-connector-project/kafka-connector/src/adapter/dist/adapters.xml) file. ([#22](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/22))
+
+  - Added a new logger configuration named `QuickStartConfluentCloud` to the factory [log4j.properties](kafka-connector-project/kafka-connector/src/adapter/dist/log4j.properties) file. ([#22](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/22))
+
+  - Improved the [QuickStart web client](examples/compose-templates/web/) by refactoring the JavaScript coied and using the CDN version of the Lightstreamer client library. ([#22](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/22)) 
+
+
 ## [1.0.6] (2024-10-10)
 
 **Documentation**
@@ -111,3 +140,4 @@ Modified the [README.md](README.md) file has follows:
 ## [0.1.0] (2024-03-17)
 
 - First public pre-release
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,34 +1,5 @@
 # Changelog
 
-## [1.0.7] (Unreleased)
-
-**Improvements and Documentation**
-
-- Improved the [README.md](README.md) file. ([#18](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/18), [#20](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/20),
-[#21](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/21),
-[#22](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/22))  
-
-- Significantly reorganized the [examples](examples) folder. Specifically:
-
-  - Moved the quick start examples for specific vendors (Confluent, Redpanda, Aiven, and Axual) into dedicated subfolders under [examples/vendors](examples/vendors/). ([#20](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/20))
-
-  - Adjusted the script files to align with the updated layout of the examples folder. ([#20](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/20))
-
-  - Improved the `docker-compose.yml` and `README.md` files within the quick start folders. ([#20](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/20))
-
-  - Improved the `README.md` files within [examples/docker](examples/docker/) and [examples/docker-kafka-connect](examples/docker-kafka-connect/) folders. ([#20](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/20))
-
-  - Introduced a dedicated [README.md](examples/vendors/confluent/README.md) file for _Confluent Cloud_ along with further specific resources under [examples/vendors/confluent](examples/vendors/confluent/). ([#20](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/20), [#22](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/22))
-
-  - Added new resources to the [pictures](pictures) folder. ([#18](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/18), [#20](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/20), [#22](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/22))
-
-  - Added a new data adapter configuration named `QuickStartConfluentCloud` to the factory [adapters.xml](kafka-connector-project/kafka-connector/src/adapter/dist/adapters.xml) file. ([#22](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/22))
-
-  - Added a new logger configuration named `QuickStartConfluentCloud` to the factory [log4j.properties](kafka-connector-project/kafka-connector/src/adapter/dist/log4j.properties) file. ([#22](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/22))
-
-  - Improved the [QuickStart web client](examples/compose-templates/web/) by refactoring the JavaScript coied and using the CDN version of the Lightstreamer client library. ([#22](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/22)) 
-
-
 ## [1.0.6] (2024-10-10)
 
 **Documentation**
@@ -140,4 +111,3 @@ Modified the [README.md](README.md) file has follows:
 ## [0.1.0] (2024-03-17)
 
 - First public pre-release
-

--- a/examples/quickstart-schema-registry/docker
+++ b/examples/quickstart-schema-registry/docker
@@ -1,1 +1,1 @@
-../../../compose-templates/docker
+../compose-templates/docker

--- a/examples/quickstart-schema-registry/helpers.sh
+++ b/examples/quickstart-schema-registry/helpers.sh
@@ -1,1 +1,1 @@
-../../../compose-templates/helpers.sh
+../compose-templates/helpers.sh

--- a/examples/quickstart-schema-registry/log4j.properties
+++ b/examples/quickstart-schema-registry/log4j.properties
@@ -1,1 +1,1 @@
-../../../compose-templates/log4j.properties
+../compose-templates/log4j.properties

--- a/examples/quickstart-schema-registry/quickstart-producer
+++ b/examples/quickstart-schema-registry/quickstart-producer
@@ -1,1 +1,1 @@
-../../../quickstart-producer/
+../quickstart-producer/

--- a/examples/quickstart-schema-registry/secrets
+++ b/examples/quickstart-schema-registry/secrets
@@ -1,1 +1,1 @@
-../../../compose-templates/secrets
+../compose-templates/secrets/

--- a/examples/quickstart-schema-registry/start.sh
+++ b/examples/quickstart-schema-registry/start.sh
@@ -1,1 +1,1 @@
-../../../compose-templates/start.sh
+../compose-templates/start.sh

--- a/examples/quickstart-schema-registry/stop.sh
+++ b/examples/quickstart-schema-registry/stop.sh
@@ -1,1 +1,1 @@
-../../../compose-templates/stop.sh
+../compose-templates/stop.sh

--- a/examples/quickstart-schema-registry/web
+++ b/examples/quickstart-schema-registry/web
@@ -1,1 +1,1 @@
-../../../compose-templates/web/
+../compose-templates/web/


### PR DESCRIPTION
The `examples/quickstart-schema-registry` folder contains broken links to resources located in external directories.