### PR TITLE
Fix evaluation of template expressions

### DIFF
--- a/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/common/expressions/Expressions.java
+++ b/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/common/expressions/Expressions.java
@@ -94,7 +94,7 @@ public class Expressions {
     private static Pattern TEMPLATE_GLOBAL =
             Pattern.compile("(^[a-zA-Z0-9_-]+)(-" + SELECTION_REGEX + ")$");
     private static Pattern TEMPLATE_LOCAL =
-            Pattern.compile("(([a-zA-Z\\._]\\w*)=([a-zA-Z0-9\\.\\[\\]\\*]+)),?");
+            Pattern.compile("(([a-zA-Z\\._]\\w*)=([a-zA-Z0-9_\\.\\[\\]\\*]+)),?");
     private static Pattern SUBSCRIBED_GLOBAL = Pattern.compile("([a-zA-Z0-9_-]+)(-\\[(.*)\\])?");
     private static Pattern SUBSCRIBED_LOCAL = Pattern.compile("(([a-zA-Z\\._]\\w*)=([^,]+)),?");
     private static Pattern FIELD = Pattern.compile(SELECTION_REGEX);

--- a/kafka-connector-project/kafka-connector/src/test/java/com/lightstreamer/kafka/common/expressions/ExpressionsTest.java
+++ b/kafka-connector-project/kafka-connector/src/test/java/com/lightstreamer/kafka/common/expressions/ExpressionsTest.java
@@ -115,7 +115,11 @@ public class ExpressionsTest {
                 arguments(
                         "template-#{param1=OFFSET,param2=PARTITION,param3=TIMESTAMP}",
                         "template",
-                        Map.of("param1", "OFFSET", "param2", "PARTITION", "param3", "TIMESTAMP")));
+                        Map.of("param1", "OFFSET", "param2", "PARTITION", "param3", "TIMESTAMP")),
+                arguments(
+                        "template-#{param1=VALUE.complex_attrib_name.child_1_}",
+                        "template",
+                        Map.of("param1", "VALUE.complex_attrib_name.child_1_")));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Evaluation of the template fails when parts of the extraction expression contain underscores. For example, the following template expression is incorrectly considered invalid:

`atemplate-#{param1=VALUE.attrib_with_underscores}`
