### PR TITLE
Fix typos in README.md files

### DIFF
--- a/README.md
+++ b/README.md
@@ -904,7 +904,7 @@ Default value: `ORDER_BY_PARTITION`.
 Example:
 
 ```xml
-<param name="record.consume.with.order.strategyy">ORDER_BY_KEY</param>
+<param name="record.consume.with.order.strategy">ORDER_BY_KEY</param>
 ```
 
 #### `record.key.evaluator.type` and `record.value.evaluator.type`

--- a/examples/vendors/confluent/README.md
+++ b/examples/vendors/confluent/README.md
@@ -956,7 +956,7 @@ Default value: `ORDER_BY_PARTITION`.
 Example:
 
 ```xml
-<param name="record.consume.with.order.strategyy">ORDER_BY_KEY</param>
+<param name="record.consume.with.order.strategy">ORDER_BY_KEY</param>
 ```
 
 #### `record.key.evaluator.type` and `record.value.evaluator.type`


### PR DESCRIPTION
Documentation fixes:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L907-R907): Corrected the parameter name from `record.consume.with.order.strategyy` to `record.consume.with.order.strategy`.
* [`examples/vendors/confluent/README.md`](diffhunk://#diff-f601c67a0d86ba83e16dbc23ac3139bf4384c5c05008135ce5507fa76bddedcdL959-R959): Corrected the parameter name from `record.consume.with.order.strategyy` to `record.consume.with.order.strategy`.