### PR TITLE
Fix typos in README.md and adapters.xml files

### DIFF
--- a/README.md
+++ b/README.md
@@ -885,7 +885,7 @@ Example:
 
 #### `record.consume.with.order.strategy`
 
-_Optional but only effective if [`record.consume.with.num.threads`](#recordconsumewithnumthreads) is set to a value greater than `1` (which includes hte default value)_. The order strategy to be used for concurrent processing of the incoming deserialized records. Can be one of the following:
+_Optional but only effective if [`record.consume.with.num.threads`](#recordconsumewithnumthreads) is set to a value greater than `1` (which includes the default value)_. The order strategy to be used for concurrent processing of the incoming deserialized records. Can be one of the following:
 
 - `ORDER_BY_PARTITION`: maintain the order of records within each partition.
 

--- a/examples/vendors/confluent/README.md
+++ b/examples/vendors/confluent/README.md
@@ -937,7 +937,7 @@ Example:
 
 #### `record.consume.with.order.strategy`
 
-_Optional but only effective if [`record.consume.with.num.threads`](#recordconsumewithnumthreads) is set to a value greater than `1` (which includes hte default value)_. The order strategy to be used for concurrent processing of the incoming deserialized records. Can be one of the following:
+_Optional but only effective if [`record.consume.with.num.threads`](#recordconsumewithnumthreads) is set to a value greater than `1` (which includes the default value)_. The order strategy to be used for concurrent processing of the incoming deserialized records. Can be one of the following:
 
 - `ORDER_BY_PARTITION`: maintain the order of records within each partition.
 

--- a/kafka-connector-project/kafka-connector/src/adapter/dist/adapters.xml
+++ b/kafka-connector-project/kafka-connector/src/adapter/dist/adapters.xml
@@ -268,7 +268,7 @@
         <param name="record.consume.with.num.threads">4</param>
         -->
 
-        <!-- Optional but only effective if "record.consume.with.num.threads" is set to a value greater than 1 (which includes hte default value).
+        <!-- Optional but only effective if "record.consume.with.num.threads" is set to a value greater than 1 (which includes the default value).
              The order strategy to be used for concurrent processing of the incoming
              deserialized records. Can be one of the following:
 


### PR DESCRIPTION
Documentation fixes:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L888-R888): Corrected a typo from "hte" to "the" in the description of `record.consume.with.order.strategy`.
* [`examples/vendors/confluent/README.md`](diffhunk://#diff-f601c67a0d86ba83e16dbc23ac3139bf4384c5c05008135ce5507fa76bddedcdL940-R940): Corrected a typo from "hte" to "the" in the description of `record.consume.with.order.strategy`.