### PR TITLE
Update Quickstart Producer example

### DIFF
--- a/examples/quickstart-producer/Dockerfile
+++ b/examples/quickstart-producer/Dockerfile
@@ -18,6 +18,6 @@ RUN gradle spotlessApply build
 FROM eclipse-temurin:21-jdk
 
 # Copy the Producer jar from the previous build stage
-COPY --from=builder /app/build/libs/quickstart-producer-all.jar /usr/app/producer.jar
+COPY --from=builder /app/build/libs/quickstart-producer-all-*.jar /usr/app/producer.jar
 
 ENTRYPOINT ["java", "-jar", "/usr/app/producer.jar"]

--- a/examples/quickstart-producer/build.gradle
+++ b/examples/quickstart-producer/build.gradle
@@ -110,7 +110,6 @@ jar {
 		attributes 'Main-Class': "com.lightstreamer.kafka.examples.quick_start.producer.Producer"
 	}
 	archiveAppendix = appendix
-	archiveVersion = ''
 
 	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 	from configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }

--- a/examples/quickstart-producer/src/main/java/com/lightstreamer/kafka/examples/quick_start/producer/FeedSimulator.java
+++ b/examples/quickstart-producer/src/main/java/com/lightstreamer/kafka/examples/quick_start/producer/FeedSimulator.java
@@ -339,7 +339,7 @@ public class FeedSimulator {
             this.ref = (int) Math.round(REF_PRICES[index] * 100);
             this.min = (int) Math.ceil(MIN_PRICES[index] * 100);
             this.max = (int) Math.floor(MAX_PRICES[index] * 100);
-            
+
             this.last = open;
             this.mean = UPDATE_TIME_MEANS[index];
             this.stdDev = UPDATE_TIME_STD_DEVS[index];


### PR DESCRIPTION
This pull request makes updates to the `examples/quickstart-producer` project to improve compatibility and streamline the build process. The changes primarily focus on handling versioned JAR files and simplifying the build configuration.

### Updates to Dockerfile:

* Updated the `COPY` command in `examples/quickstart-producer/Dockerfile` to support versioned JAR files by using a wildcard pattern (`quickstart-producer-all-*.jar`) instead of a fixed filename. This allows for flexibility when the JAR file name includes version information.

### Updates to build.gradle:

* Removed the `archiveVersion` property in `examples/quickstart-producer/build.gradle` to prevent explicit versioning in the JAR file name, aligning with the updated wildcard handling in the Dockerfile.