### PR TITLE
Update Lightstreamer script source to use HTTPS

### DIFF
--- a/examples/airport-demo/client/web/src/index.html
+++ b/examples/airport-demo/client/web/src/index.html
@@ -81,7 +81,7 @@
     <div class="disc">Simulated data.</div>
 
     <!-- load Lightstreamer libraries -->
-    <script src="http://unpkg.com/lightstreamer-client-web/lightstreamer.min.js" data-lightstreamer-ns="Ls"></script>
+    <script src="https://unpkg.com/lightstreamer-client-web/lightstreamer.min.js" data-lightstreamer-ns="Ls"></script>
 
     <script src="js/const.js"></script>
     <script src="js/index.js"></script>


### PR DESCRIPTION
This pull request includes a minor update to the `examples/airport-demo/client/web/src/index.html` file. 

It updates the `Lightstreamer` library script URL from `http` to `https` to ensure secure loading of the library.