### PR TITLE
Fix null payload

### DIFF
--- a/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/adapters/mapping/selectors/avro/GenericRecordSelectorsSuppliers.java
+++ b/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/adapters/mapping/selectors/avro/GenericRecordSelectorsSuppliers.java
@@ -215,7 +215,8 @@ public class GenericRecordSelectorsSuppliers
         @Override
         public Data extractKey(KafkaRecord<GenericRecord, ?> record, boolean checkScalar)
                 throws ValueException {
-            return super.eval(AvroNode.fromContainer(record.key()), checkScalar);
+            Node<AvroNode> node = Node.checkNull(() -> record.key(), AvroNode::fromContainer);
+            return super.eval(node, checkScalar);
         }
     }
 
@@ -251,7 +252,8 @@ public class GenericRecordSelectorsSuppliers
         @Override
         public Data extractValue(KafkaRecord<?, GenericRecord> record, boolean checkScalar)
                 throws ValueException {
-            return super.eval(AvroNode.fromContainer(record.value()), checkScalar);
+            Node<AvroNode> node = Node.checkNull(() -> record.value(), AvroNode::fromContainer);
+            return super.eval(node, checkScalar);
         }
     }
 

--- a/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/adapters/mapping/selectors/avro/GenericRecordSelectorsSuppliers.java
+++ b/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/adapters/mapping/selectors/avro/GenericRecordSelectorsSuppliers.java
@@ -215,8 +215,7 @@ public class GenericRecordSelectorsSuppliers
         @Override
         public Data extractKey(KafkaRecord<GenericRecord, ?> record, boolean checkScalar)
                 throws ValueException {
-            Node<AvroNode> node = Node.checkNull(() -> record.key(), AvroNode::fromContainer);
-            return super.eval(node, checkScalar);
+            return super.eval(() -> record.key(), AvroNode::fromContainer, checkScalar);
         }
     }
 
@@ -252,8 +251,7 @@ public class GenericRecordSelectorsSuppliers
         @Override
         public Data extractValue(KafkaRecord<?, GenericRecord> record, boolean checkScalar)
                 throws ValueException {
-            Node<AvroNode> node = Node.checkNull(() -> record.value(), AvroNode::fromContainer);
-            return super.eval(node, checkScalar);
+            return super.eval(() -> record.value(), AvroNode::fromContainer, checkScalar);
         }
     }
 

--- a/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/adapters/mapping/selectors/json/JsonNodeSelectorsSuppliers.java
+++ b/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/adapters/mapping/selectors/json/JsonNodeSelectorsSuppliers.java
@@ -123,7 +123,8 @@ public class JsonNodeSelectorsSuppliers implements KeyValueSelectorSuppliersMake
         @Override
         public Data extractKey(KafkaRecord<JsonNode, ?> record, boolean checkScalar)
                 throws ValueException {
-            return super.eval(new JsonNodeNode(record.key()), checkScalar);
+            Node<JsonNodeNode> node = Node.checkNull(() -> record.key(), JsonNodeNode::new);
+            return super.eval(node, checkScalar);
         }
     }
 
@@ -162,7 +163,8 @@ public class JsonNodeSelectorsSuppliers implements KeyValueSelectorSuppliersMake
         @Override
         public Data extractValue(KafkaRecord<?, JsonNode> record, boolean checkScalar)
                 throws ValueException {
-            return super.eval(new JsonNodeNode(record.value()), checkScalar);
+            Node<JsonNodeNode> node = Node.checkNull(() -> record.value(), JsonNodeNode::new);
+            return super.eval(node, checkScalar);
         }
     }
 

--- a/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/adapters/mapping/selectors/json/JsonNodeSelectorsSuppliers.java
+++ b/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/adapters/mapping/selectors/json/JsonNodeSelectorsSuppliers.java
@@ -123,8 +123,7 @@ public class JsonNodeSelectorsSuppliers implements KeyValueSelectorSuppliersMake
         @Override
         public Data extractKey(KafkaRecord<JsonNode, ?> record, boolean checkScalar)
                 throws ValueException {
-            Node<JsonNodeNode> node = Node.checkNull(() -> record.key(), JsonNodeNode::new);
-            return super.eval(node, checkScalar);
+            return super.eval(() -> record.key(), JsonNodeNode::new, checkScalar);
         }
     }
 
@@ -163,8 +162,7 @@ public class JsonNodeSelectorsSuppliers implements KeyValueSelectorSuppliersMake
         @Override
         public Data extractValue(KafkaRecord<?, JsonNode> record, boolean checkScalar)
                 throws ValueException {
-            Node<JsonNodeNode> node = Node.checkNull(() -> record.value(), JsonNodeNode::new);
-            return super.eval(node, checkScalar);
+            return super.eval(() -> record.value(), JsonNodeNode::new, checkScalar);
         }
     }
 

--- a/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/adapters/mapping/selectors/protobuf/DynamicMessageSelectorSuppliers.java
+++ b/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/adapters/mapping/selectors/protobuf/DynamicMessageSelectorSuppliers.java
@@ -341,7 +341,8 @@ public class DynamicMessageSelectorSuppliers
         @Override
         public Data extractKey(KafkaRecord<DynamicMessage, ?> record, boolean checkScalar)
                 throws ValueException {
-            return super.eval(new MessageWrapperNode(record.key()), checkScalar);
+            Node<ProtobufNode> node = Node.checkNull(() -> record.key(), MessageWrapperNode::new);
+            return super.eval(node, checkScalar);
         }
     }
 
@@ -398,7 +399,10 @@ public class DynamicMessageSelectorSuppliers
         @Override
         public Data extractValue(KafkaRecord<?, DynamicMessage> record, boolean checkScalar)
                 throws ValueException {
-            return super.eval(new MessageWrapperNode(record.value()), checkScalar);
+
+            Node<ProtobufNode> node =
+                    Node.checkNull(() -> record.value(), MessageWrapperNode::new);
+            return super.eval(node, checkScalar);
         }
     }
 

--- a/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/adapters/mapping/selectors/protobuf/DynamicMessageSelectorSuppliers.java
+++ b/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/adapters/mapping/selectors/protobuf/DynamicMessageSelectorSuppliers.java
@@ -400,7 +400,8 @@ public class DynamicMessageSelectorSuppliers
         public Data extractValue(KafkaRecord<?, DynamicMessage> record, boolean checkScalar)
                 throws ValueException {
 
-            Node<ProtobufNode> node = Node.checkNull(() -> record.value(), MessageWrapperNode::new);
+            Node<ProtobufNode> node =
+                    Node.checkNull(() -> record.value(), MessageWrapperNode::new);
             return super.eval(node, checkScalar);
         }
     }

--- a/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/adapters/mapping/selectors/protobuf/DynamicMessageSelectorSuppliers.java
+++ b/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/adapters/mapping/selectors/protobuf/DynamicMessageSelectorSuppliers.java
@@ -400,8 +400,7 @@ public class DynamicMessageSelectorSuppliers
         public Data extractValue(KafkaRecord<?, DynamicMessage> record, boolean checkScalar)
                 throws ValueException {
 
-            Node<ProtobufNode> node =
-                    Node.checkNull(() -> record.value(), MessageWrapperNode::new);
+            Node<ProtobufNode> node = Node.checkNull(() -> record.value(), MessageWrapperNode::new);
             return super.eval(node, checkScalar);
         }
     }

--- a/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/adapters/mapping/selectors/protobuf/DynamicMessageSelectorSuppliers.java
+++ b/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/adapters/mapping/selectors/protobuf/DynamicMessageSelectorSuppliers.java
@@ -341,8 +341,7 @@ public class DynamicMessageSelectorSuppliers
         @Override
         public Data extractKey(KafkaRecord<DynamicMessage, ?> record, boolean checkScalar)
                 throws ValueException {
-            Node<ProtobufNode> node = Node.checkNull(() -> record.key(), MessageWrapperNode::new);
-            return super.eval(node, checkScalar);
+            return super.eval(() -> record.key(), MessageWrapperNode::new, checkScalar);
         }
     }
 
@@ -399,10 +398,7 @@ public class DynamicMessageSelectorSuppliers
         @Override
         public Data extractValue(KafkaRecord<?, DynamicMessage> record, boolean checkScalar)
                 throws ValueException {
-
-            Node<ProtobufNode> node =
-                    Node.checkNull(() -> record.value(), MessageWrapperNode::new);
-            return super.eval(node, checkScalar);
+            return super.eval(() -> record.value(), MessageWrapperNode::new, checkScalar);
         }
     }
 

--- a/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/common/mapping/selectors/HeadersSelectorSupplier.java
+++ b/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/common/mapping/selectors/HeadersSelectorSupplier.java
@@ -157,8 +157,10 @@ public class HeadersSelectorSupplier implements SelectorSupplier<GenericSelector
 
         @Override
         public Data extract(KafkaRecord<?, ?> record, boolean checkScalar) throws ValueException {
-            Node<HeaderNode> headersNode = Node.rootNode(() -> new HeadersNode(record.headers()));
-            return super.eval(headersNode, checkScalar);
+            return super.eval(
+                    () -> record.headers(),
+                    h -> Node.rootNode(() -> new HeadersNode(h)),
+                    checkScalar);
         }
     }
 

--- a/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/common/mapping/selectors/Parsers.java
+++ b/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/common/mapping/selectors/Parsers.java
@@ -65,6 +65,15 @@ public interface Parsers {
             return "";
         }
 
+        static <K, T extends Node<T>> Node<T> checkNull(
+                Supplier<K> obj, Function<K, Node<T>> nodeFactory) {
+            K object = obj.get();
+            if (object == null) {
+                return nullNode();
+            }
+            return nodeFactory.apply(object);
+        }
+
         @SuppressWarnings("unchecked")
         static <T extends Node<T>> Node<T> nullNode() {
             return (Node<T>) NullNode.INSTANCE;
@@ -74,7 +83,7 @@ public interface Parsers {
 
             private static final NullNode<?> INSTANCE = new NullNode<>();
 
-            public NullNode() {
+            private NullNode() {
                 // private constructor to prevent instantiation
             }
 

--- a/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/common/mapping/selectors/StructuredBaseSelector.java
+++ b/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/common/mapping/selectors/StructuredBaseSelector.java
@@ -27,6 +27,8 @@ import com.lightstreamer.kafka.common.mapping.selectors.Parsers.ParsingContext;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 public abstract class StructuredBaseSelector<T extends Node<T>> extends BaseSelector {
 
@@ -123,7 +125,9 @@ public abstract class StructuredBaseSelector<T extends Node<T>> extends BaseSele
         this.evaluator = parser.parse(ctx);
     }
 
-    protected final Data eval(Node<T> node, boolean checkScalar) {
+    protected final <P> Data eval(
+            Supplier<P> payloadSupplier, Function<P, Node<T>> nodeFactory, boolean checkScalar) {
+        Node<T> node = Node.checkNull(payloadSupplier, nodeFactory);
         LinkedNodeEvaluator<T> current = evaluator;
         while (current != null) {
             node = current.eval(node);

--- a/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/connect/mapping/selectors/ConnectSelectorsSuppliers.java
+++ b/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/connect/mapping/selectors/ConnectSelectorsSuppliers.java
@@ -186,7 +186,8 @@ public class ConnectSelectorsSuppliers implements KeyValueSelectorSuppliers<Obje
         @Override
         public Data extractKey(KafkaRecord<Object, ?> record, boolean checkScalar)
                 throws ValueException {
-            return eval(asNode((KafkaSinkRecord) record), checkScalar);
+
+            return eval(() -> ((KafkaSinkRecord) record), this::asNode, checkScalar);
         }
 
         private Node<SchemaAndValueNode> asNode(KafkaRecord.KafkaSinkRecord sinkRecord) {
@@ -216,7 +217,7 @@ public class ConnectSelectorsSuppliers implements KeyValueSelectorSuppliers<Obje
         @Override
         public Data extractValue(KafkaRecord<?, Object> record, boolean checkScalar)
                 throws ValueException {
-            return eval(asNode((KafkaSinkRecord) record), checkScalar);
+            return eval(() -> ((KafkaSinkRecord) record), this::asNode, checkScalar);
         }
 
         private Node<SchemaAndValueNode> asNode(KafkaRecord.KafkaSinkRecord sinkRecord) {

--- a/kafka-connector-project/kafka-connector/src/test/java/com/lightstreamer/kafka/adapters/mapping/selectors/avro/GenericRecordSelectorsSuppliersTest.java
+++ b/kafka-connector-project/kafka-connector/src/test/java/com/lightstreamer/kafka/adapters/mapping/selectors/avro/GenericRecordSelectorsSuppliersTest.java
@@ -188,6 +188,42 @@ public class GenericRecordSelectorsSuppliersTest {
     @ParameterizedTest(name = "[{index}] {arguments}")
     @CsvSource(
             useHeadersInDisplayName = true,
+            textBlock =
+                    """
+                EXPRESSION,                  EXPECTED_ERROR_MESSAGE
+                VALUE,                       The expression [VALUE] must evaluate to a non-complex object
+                VALUE.no_attrib,             Field [no_attrib] not found
+                VALUE.children[0].no_attrib, Field [no_attrib] not found
+                VALUE.no_children[0],        Field [no_children] not found
+                VALUE.name[0],               Field [name] is not indexed
+                VALUE.name['no_key'],        Cannot retrieve field [no_key] from a scalar object
+                VALUE.name.no_key,           Cannot retrieve field [no_key] from a scalar object
+                VALUE.preferences,           The expression [VALUE.preferences] must evaluate to a non-complex object
+                VALUE.documents,             The expression [VALUE.documents] must evaluate to a non-complex object
+                VALUE.children,              The expression [VALUE.children] must evaluate to a non-complex object
+                VALUE.children[0]['no_key'], Field [no_key] not found
+                VALUE.children[0],           The expression [VALUE.children[0]] must evaluate to a non-complex object
+                VALUE.children[3].name,      Cannot retrieve field [name] from a null object
+                VALUE.children[4],           Field not found at index [4]
+                VALUE.children[4].name,      Field not found at index [4]
+                VALUE.type.attrib,           Cannot retrieve field [attrib] from a scalar object
+                VALUE.emptyArray[0],         Field not found at index [0]
+                VALUE.nullArray[0],          Cannot retrieve index [0] from null object [nullArray]
+                    """)
+    public void shouldNotExtractValue(String expressionStr, String errorMessage) {
+        ValueException ve =
+                assertThrows(
+                        ValueException.class,
+                        () ->
+                                valueSelector(Expression(expressionStr))
+                                        .extractValue(fromValue(SAMPLE_MESSAGE))
+                                        .text());
+        assertThat(ve.getMessage()).isEqualTo(errorMessage);
+    }
+
+    @ParameterizedTest(name = "[{index}] {arguments}")
+    @CsvSource(
+            useHeadersInDisplayName = true,
             delimiter = '|', // Required because of the expected value for input VALUE.signature
             textBlock =
                     """
@@ -218,32 +254,18 @@ public class GenericRecordSelectorsSuppliersTest {
             textBlock =
                     """
                 EXPRESSION,                  EXPECTED_ERROR_MESSAGE
-                VALUE,                       The expression [VALUE] must evaluate to a non-complex object
-                VALUE.no_attrib,             Field [no_attrib] not found
-                VALUE.children[0].no_attrib, Field [no_attrib] not found
-                VALUE.no_children[0],        Field [no_children] not found
-                VALUE.name[0],               Field [name] is not indexed
-                VALUE.name['no_key'],        Cannot retrieve field [no_key] from a scalar object
-                VALUE.name.no_key,           Cannot retrieve field [no_key] from a scalar object
-                VALUE.preferences,           The expression [VALUE.preferences] must evaluate to a non-complex object
-                VALUE.documents,             The expression [VALUE.documents] must evaluate to a non-complex object
-                VALUE.children,              The expression [VALUE.children] must evaluate to a non-complex object
-                VALUE.children[0]['no_key'], Field [no_key] not found
-                VALUE.children[0],           The expression [VALUE.children[0]] must evaluate to a non-complex object
-                VALUE.children[3].name,      Cannot retrieve field [name] from a null object
-                VALUE.children[4],           Field not found at index [4]
-                VALUE.children[4].name,      Field not found at index [4]
-                VALUE.type.attrib,           Cannot retrieve field [attrib] from a scalar object
-                VALUE.emptyArray[0],         Field not found at index [0]
-                VALUE.nullArray[0],          Cannot retrieve index [0] from null object [nullArray]
+                VALUE.no_attrib,             Cannot retrieve field [no_attrib] from a null object
+                VALUE.children[0].no_attrib, Cannot retrieve field [children] from a null object
+                VALUE.no_children[0],        Cannot retrieve field [no_children] from a null object
                     """)
-    public void shouldNotExtractValue(String expressionStr, String errorMessage) {
+    public void shouldHandleNullValue(String expressionStr, String errorMessage)
+            throws ExtractionException {
         ValueException ve =
                 assertThrows(
                         ValueException.class,
                         () ->
                                 valueSelector(Expression(expressionStr))
-                                        .extractValue(fromValue(SAMPLE_MESSAGE))
+                                        .extractValue(fromValue((GenericRecord) null))
                                         .text());
         assertThat(ve.getMessage()).isEqualTo(errorMessage);
     }
@@ -289,6 +311,40 @@ public class GenericRecordSelectorsSuppliersTest {
     @ParameterizedTest(name = "[{index}] {arguments}")
     @CsvSource(
             useHeadersInDisplayName = true,
+            textBlock =
+                    """
+                EXPRESSION,                EXPECTED_ERROR_MESSAGE
+                KEY,                       The expression [KEY] must evaluate to a non-complex object
+                KEY.no_attrib,             Field [no_attrib] not found
+                KEY.children[0].no_attrib, Field [no_attrib] not found
+                KEY.no_children[0],        Field [no_children] not found
+                KEY.name[0],               Field [name] is not indexed
+                KEY.name['no_key'],        Cannot retrieve field [no_key] from a scalar object
+                KEY.name.no_key,           Cannot retrieve field [no_key] from a scalar object
+                KEY.preferences,           The expression [KEY.preferences] must evaluate to a non-complex object
+                KEY.children,              The expression [KEY.children] must evaluate to a non-complex object
+                KEY.children[0]['no_key'], Field [no_key] not found
+                KEY.children[0],           The expression [KEY.children[0]] must evaluate to a non-complex object
+                KEY.children[3].name,      Cannot retrieve field [name] from a null object
+                KEY.children[4],           Field not found at index [4]
+                KEY.children[4].name,      Field not found at index [4]
+                KEY.type.attrib,           Cannot retrieve field [attrib] from a scalar object
+                KEY.nullArray[0],          Cannot retrieve index [0] from null object [nullArray]
+                    """)
+    public void shouldNotExtractKey(String expressionStr, String errorMessage) {
+        ValueException ve =
+                assertThrows(
+                        ValueException.class,
+                        () ->
+                                keySelector(Expression(expressionStr))
+                                        .extractKey(fromKey(SAMPLE_MESSAGE))
+                                        .text());
+        assertThat(ve.getMessage()).isEqualTo(errorMessage);
+    }
+
+    @ParameterizedTest(name = "[{index}] {arguments}")
+    @CsvSource(
+            useHeadersInDisplayName = true,
             delimiter = '|', // Required because of the expected value for input VALUE.signature
             textBlock =
                     """
@@ -318,31 +374,19 @@ public class GenericRecordSelectorsSuppliersTest {
             useHeadersInDisplayName = true,
             textBlock =
                     """
-                EXPRESSION,                EXPECTED_ERROR_MESSAGE
-                KEY,                       The expression [KEY] must evaluate to a non-complex object
-                KEY.no_attrib,             Field [no_attrib] not found
-                KEY.children[0].no_attrib, Field [no_attrib] not found
-                KEY.no_children[0],        Field [no_children] not found
-                KEY.name[0],               Field [name] is not indexed
-                KEY.name['no_key'],        Cannot retrieve field [no_key] from a scalar object
-                KEY.name.no_key,           Cannot retrieve field [no_key] from a scalar object
-                KEY.preferences,           The expression [KEY.preferences] must evaluate to a non-complex object
-                KEY.children,              The expression [KEY.children] must evaluate to a non-complex object
-                KEY.children[0]['no_key'], Field [no_key] not found
-                KEY.children[0],           The expression [KEY.children[0]] must evaluate to a non-complex object
-                KEY.children[3].name,      Cannot retrieve field [name] from a null object
-                KEY.children[4],           Field not found at index [4]
-                KEY.children[4].name,      Field not found at index [4]
-                KEY.type.attrib,           Cannot retrieve field [attrib] from a scalar object
-                KEY.nullArray[0],          Cannot retrieve index [0] from null object [nullArray]
+                EXPRESSION,                  EXPECTED_ERROR_MESSAGE
+                KEY.no_attrib,             Cannot retrieve field [no_attrib] from a null object
+                KEY.children[0].no_attrib, Cannot retrieve field [children] from a null object
+                KEY.no_children[0],        Cannot retrieve field [no_children] from a null object
                     """)
-    public void shouldNotExtractKey(String expressionStr, String errorMessage) {
+    public void shouldHandleNullKey(String expressionStr, String errorMessage)
+            throws ExtractionException {
         ValueException ve =
                 assertThrows(
                         ValueException.class,
                         () ->
                                 keySelector(Expression(expressionStr))
-                                        .extractKey(fromKey(SAMPLE_MESSAGE))
+                                        .extractKey(fromKey((GenericRecord) null))
                                         .text());
         assertThat(ve.getMessage()).isEqualTo(errorMessage);
     }

--- a/kafka-connector-project/kafka-connector/src/test/java/com/lightstreamer/kafka/adapters/mapping/selectors/json/JsonNodeSelectorsSuppliersTest.java
+++ b/kafka-connector-project/kafka-connector/src/test/java/com/lightstreamer/kafka/adapters/mapping/selectors/json/JsonNodeSelectorsSuppliersTest.java
@@ -263,6 +263,28 @@ public class JsonNodeSelectorsSuppliersTest {
             useHeadersInDisplayName = true,
             textBlock =
                     """
+                EXPRESSION,                  EXPECTED_ERROR_MESSAGE
+                VALUE.no_attrib,             Cannot retrieve field [no_attrib] from a null object
+                VALUE.children[0].no_attrib, Cannot retrieve field [children] from a null object
+                VALUE.no_children[0],        Cannot retrieve field [no_children] from a null object
+                    """)
+    public void shouldHandleNullValue(String expressionStr, String errorMessage)
+            throws ExtractionException {
+        ValueException ve =
+                assertThrows(
+                        ValueException.class,
+                        () ->
+                                valueSelector(Expression(expressionStr))
+                                        .extractValue(fromValue((JsonNode) null))
+                                        .text());
+        assertThat(ve.getMessage()).isEqualTo(errorMessage);
+    }
+
+    @ParameterizedTest(name = "[{index}] {arguments}")
+    @CsvSource(
+            useHeadersInDisplayName = true,
+            textBlock =
+                    """
                 EXPRESSION,                          EXPECTED
                 KEY.name,                            joe
                 KEY.signature,                       YWJjZA==
@@ -287,6 +309,38 @@ public class JsonNodeSelectorsSuppliersTest {
         } else {
             subject.isEqualTo(expected);
         }
+    }
+
+    @ParameterizedTest(name = "[{index}] {arguments}")
+    @CsvSource(
+            useHeadersInDisplayName = true,
+            textBlock =
+                    """
+                EXPRESSION,                EXPECTED_ERROR_MESSAGE
+                KEY,                       The expression [KEY] must evaluate to a non-complex object
+                KEY.no_attrib,             Field [no_attrib] not found
+                KEY.children[0].no_attrib, Field [no_attrib] not found
+                KEY.no_children[0],        Field [no_children] not found
+                KEY.name[0],               Field [name] is not indexed
+                KEY.name['no_key'],        Cannot retrieve field [no_key] from a scalar object
+                KEY.name.no_key,           Cannot retrieve field [no_key] from a scalar object
+                KEY.children,              The expression [KEY.children] must evaluate to a non-complex object
+                KEY.children[0]['no_key'], Field [no_key] not found
+                KEY.children[0],           The expression [KEY.children[0]] must evaluate to a non-complex object
+                KEY.children[3].name,      Cannot retrieve field [name] from a null object
+                KEY.children[4],           Field not found at index [4]
+                KEY.children[4].name,      Field not found at index [4]
+                KEY.nullArray[0],          Cannot retrieve index [0] from null object [nullArray]
+                    """)
+    public void shouldNotExtractKey(String expressionStr, String errorMessage) {
+        ValueException ve =
+                assertThrows(
+                        ValueException.class,
+                        () ->
+                                keySelector(Expression(expressionStr))
+                                        .extractKey(fromKey(SAMPLE_MESSAGE))
+                                        .text());
+        assertThat(ve.getMessage()).isEqualTo(errorMessage);
     }
 
     @ParameterizedTest(name = "[{index}] {arguments}")
@@ -330,29 +384,19 @@ public class JsonNodeSelectorsSuppliersTest {
             useHeadersInDisplayName = true,
             textBlock =
                     """
-                EXPRESSION,                EXPECTED_ERROR_MESSAGE
-                KEY,                       The expression [KEY] must evaluate to a non-complex object
-                KEY.no_attrib,             Field [no_attrib] not found
-                KEY.children[0].no_attrib, Field [no_attrib] not found
-                KEY.no_children[0],        Field [no_children] not found
-                KEY.name[0],               Field [name] is not indexed
-                KEY.name['no_key'],        Cannot retrieve field [no_key] from a scalar object
-                KEY.name.no_key,           Cannot retrieve field [no_key] from a scalar object
-                KEY.children,              The expression [KEY.children] must evaluate to a non-complex object
-                KEY.children[0]['no_key'], Field [no_key] not found
-                KEY.children[0],           The expression [KEY.children[0]] must evaluate to a non-complex object
-                KEY.children[3].name,      Cannot retrieve field [name] from a null object
-                KEY.children[4],           Field not found at index [4]
-                KEY.children[4].name,      Field not found at index [4]
-                KEY.nullArray[0],          Cannot retrieve index [0] from null object [nullArray]
+                EXPRESSION,                  EXPECTED_ERROR_MESSAGE
+                KEY.no_attrib,             Cannot retrieve field [no_attrib] from a null object
+                KEY.children[0].no_attrib, Cannot retrieve field [children] from a null object
+                KEY.no_children[0],        Cannot retrieve field [no_children] from a null object
                     """)
-    public void shouldNotExtractKey(String expressionStr, String errorMessage) {
+    public void shouldHandleNullKey(String expressionStr, String errorMessage)
+            throws ExtractionException {
         ValueException ve =
                 assertThrows(
                         ValueException.class,
                         () ->
                                 keySelector(Expression(expressionStr))
-                                        .extractKey(fromKey(SAMPLE_MESSAGE))
+                                        .extractKey(fromKey((JsonNode) null))
                                         .text());
         assertThat(ve.getMessage()).isEqualTo(errorMessage);
     }

--- a/kafka-connector-project/kafka-connector/src/test/java/com/lightstreamer/kafka/adapters/mapping/selectors/protobuf/DynamicMessageSelectorSuppliersTest.java
+++ b/kafka-connector-project/kafka-connector/src/test/java/com/lightstreamer/kafka/adapters/mapping/selectors/protobuf/DynamicMessageSelectorSuppliersTest.java
@@ -205,28 +205,6 @@ public class DynamicMessageSelectorSuppliersTest {
     @ParameterizedTest(name = "[{index}] {arguments}")
     @CsvSource(
             useHeadersInDisplayName = true,
-            delimiter = '|', // Required because of the expected value for input VALUE.signature
-            textBlock =
-                    """
-                EXPRESSION         | EXPECTED
-                VALUE              | name: "mike"\\nmainAddress {\\n  city: "London"\\n  country {\\n    name: "England"\\n  }\\n}\\nphoneNumbers: "111111"\\nphoneNumbers: "222222"\\nfriends {\\n  name: "alex"\\n}\\njob: ARTIST\\n
-                VALUE.phoneNumbers | phoneNumbers: "111111"\\nphoneNumbers: "222222"\\n
-                VALUE.friends      | friends {\\n  name: "alex"\\n}\\n
-                VALUE.friends[0]   | name: "alex"\\n
-                VALUE.mainAddress  | city: "London"\\ncountry {\\n  name: "England"\\n}\\n
-                    """)
-    public void shouldExtractValueWithNonScalars(String expressionStr, String expected)
-            throws ExtractionException {
-        String extractedData =
-                valueSelector(Expression(expressionStr))
-                        .extractValue(fromValue(SAMPLE_MESSAGE_V2), false)
-                        .text();
-        assertThat(extractedData).isEqualTo(unescape(expected));
-    }
-
-    @ParameterizedTest(name = "[{index}] {arguments}")
-    @CsvSource(
-            useHeadersInDisplayName = true,
             textBlock =
                     """
                 EXPRESSION,                     EXPECTED_ERROR_MESSAGE
@@ -251,6 +229,50 @@ public class DynamicMessageSelectorSuppliersTest {
                         () ->
                                 valueSelector(Expression(expressionStr))
                                         .extractValue(fromValue(SAMPLE_MESSAGE))
+                                        .text());
+        assertThat(ve.getMessage()).isEqualTo(errorMessage);
+    }
+
+    @ParameterizedTest(name = "[{index}] {arguments}")
+    @CsvSource(
+            useHeadersInDisplayName = true,
+            delimiter = '|', // Required because of the expected value for input VALUE.signature
+            textBlock =
+                    """
+                EXPRESSION         | EXPECTED
+                VALUE              | name: "mike"\\nmainAddress {\\n  city: "London"\\n  country {\\n    name: "England"\\n  }\\n}\\nphoneNumbers: "111111"\\nphoneNumbers: "222222"\\nfriends {\\n  name: "alex"\\n}\\njob: ARTIST\\n
+                VALUE.phoneNumbers | phoneNumbers: "111111"\\nphoneNumbers: "222222"\\n
+                VALUE.friends      | friends {\\n  name: "alex"\\n}\\n
+                VALUE.friends[0]   | name: "alex"\\n
+                VALUE.mainAddress  | city: "London"\\ncountry {\\n  name: "England"\\n}\\n
+                    """)
+    public void shouldExtractValueWithNonScalars(String expressionStr, String expected)
+            throws ExtractionException {
+        String extractedData =
+                valueSelector(Expression(expressionStr))
+                        .extractValue(fromValue(SAMPLE_MESSAGE_V2), false)
+                        .text();
+        assertThat(extractedData).isEqualTo(unescape(expected));
+    }
+
+    @ParameterizedTest(name = "[{index}] {arguments}")
+    @CsvSource(
+            useHeadersInDisplayName = true,
+            textBlock =
+                    """
+                EXPRESSION,                  EXPECTED_ERROR_MESSAGE
+                VALUE.no_attrib,             Cannot retrieve field [no_attrib] from a null object
+                VALUE.children[0].no_attrib, Cannot retrieve field [children] from a null object
+                VALUE.no_children[0],        Cannot retrieve field [no_children] from a null object
+                    """)
+    public void shouldHandleNullValue(String expressionStr, String errorMessage)
+            throws ExtractionException {
+        ValueException ve =
+                assertThrows(
+                        ValueException.class,
+                        () ->
+                                valueSelector(Expression(expressionStr))
+                                        .extractValue(fromValue((DynamicMessage) null))
                                         .text());
         assertThat(ve.getMessage()).isEqualTo(errorMessage);
     }
@@ -294,28 +316,6 @@ public class DynamicMessageSelectorSuppliersTest {
     @ParameterizedTest(name = "[{index}] {arguments}")
     @CsvSource(
             useHeadersInDisplayName = true,
-            delimiter = '|',
-            textBlock =
-                    """
-                EXPRESSION       | EXPECTED
-                KEY              | name: "mike"\\nmainAddress {\\n  city: "London"\\n  country {\\n    name: "England"\\n  }\\n}\\nphoneNumbers: "111111"\\nphoneNumbers: "222222"\\nfriends {\\n  name: "alex"\\n}\\njob: ARTIST\\n
-                KEY.phoneNumbers | phoneNumbers: "111111"\\nphoneNumbers: "222222"\\n
-                KEY.friends      | friends {\\n  name: "alex"\\n}\\n
-                KEY.friends[0]   | name: "alex"\\n
-                KEY.mainAddress  | city: "London"\\ncountry {\\n  name: "England"\\n}\\n
-                    """)
-    public void shouldExtractKeyWithNonScalars(String expressionStr, String expected)
-            throws ExtractionException, ValueException, InvalidEscapeSequenceException {
-        String extractedData =
-                keySelector(Expression(expressionStr))
-                        .extractKey(fromKey(SAMPLE_MESSAGE_V2), false)
-                        .text();
-        assertThat(extractedData).isEqualTo(unescape(expected));
-    }
-
-    @ParameterizedTest(name = "[{index}] {arguments}")
-    @CsvSource(
-            useHeadersInDisplayName = true,
             textBlock =
                     """
                 EXPRESSION,                   EXPECTED_ERROR_MESSAGE
@@ -340,6 +340,50 @@ public class DynamicMessageSelectorSuppliersTest {
                         () ->
                                 keySelector(Expression(expressionStr))
                                         .extractKey(fromKey(SAMPLE_MESSAGE))
+                                        .text());
+        assertThat(ve.getMessage()).isEqualTo(errorMessage);
+    }
+
+    @ParameterizedTest(name = "[{index}] {arguments}")
+    @CsvSource(
+            useHeadersInDisplayName = true,
+            delimiter = '|',
+            textBlock =
+                    """
+                EXPRESSION       | EXPECTED
+                KEY              | name: "mike"\\nmainAddress {\\n  city: "London"\\n  country {\\n    name: "England"\\n  }\\n}\\nphoneNumbers: "111111"\\nphoneNumbers: "222222"\\nfriends {\\n  name: "alex"\\n}\\njob: ARTIST\\n
+                KEY.phoneNumbers | phoneNumbers: "111111"\\nphoneNumbers: "222222"\\n
+                KEY.friends      | friends {\\n  name: "alex"\\n}\\n
+                KEY.friends[0]   | name: "alex"\\n
+                KEY.mainAddress  | city: "London"\\ncountry {\\n  name: "England"\\n}\\n
+                    """)
+    public void shouldExtractKeyWithNonScalars(String expressionStr, String expected)
+            throws ExtractionException, ValueException, InvalidEscapeSequenceException {
+        String extractedData =
+                keySelector(Expression(expressionStr))
+                        .extractKey(fromKey(SAMPLE_MESSAGE_V2), false)
+                        .text();
+        assertThat(extractedData).isEqualTo(unescape(expected));
+    }
+
+    @ParameterizedTest(name = "[{index}] {arguments}")
+    @CsvSource(
+            useHeadersInDisplayName = true,
+            textBlock =
+                    """
+                EXPRESSION,                  EXPECTED_ERROR_MESSAGE
+                KEY.no_attrib,             Cannot retrieve field [no_attrib] from a null object
+                KEY.children[0].no_attrib, Cannot retrieve field [children] from a null object
+                KEY.no_children[0],        Cannot retrieve field [no_children] from a null object
+                    """)
+    public void shouldHandleNullKey(String expressionStr, String errorMessage)
+            throws ExtractionException {
+        ValueException ve =
+                assertThrows(
+                        ValueException.class,
+                        () ->
+                                keySelector(Expression(expressionStr))
+                                        .extractKey(fromKey((DynamicMessage) null))
                                         .text());
         assertThat(ve.getMessage()).isEqualTo(errorMessage);
     }

--- a/kafka-connector-project/kafka-connector/src/test/java/com/lightstreamer/kafka/connect/mapping/selectors/ConnectSelectorsSuppliersTest.java
+++ b/kafka-connector-project/kafka-connector/src/test/java/com/lightstreamer/kafka/connect/mapping/selectors/ConnectSelectorsSuppliersTest.java
@@ -140,28 +140,6 @@ public class ConnectSelectorsSuppliersTest {
     @ParameterizedTest(name = "[{index}] {arguments}")
     @CsvSource(
             useHeadersInDisplayName = true,
-            delimiter = '|', // Required because of the expected value for input VALUE.signature
-            textBlock =
-                    """
-                EXPRESSION     |  EXPECTED
-                VALUE          |  {"name":"joe","signature":"YWJjZA==","children":[],"nullArray":null}
-                VALUE.children | []
-                VALUE.name     | joe
-                    """)
-    public void shouldExtractValueWithNonScalars(String expression, String expected)
-            throws ExtractionException {
-        String text =
-                valueSelector(expression)
-                        .extractValue(
-                                sinkFromValue("topic", SIMPLE_STRUCT.schema(), SIMPLE_STRUCT),
-                                false)
-                        .text();
-        assertThat(text).isEqualTo(expected);
-    }
-
-    @ParameterizedTest(name = "[{index}] {arguments}")
-    @CsvSource(
-            useHeadersInDisplayName = true,
             textBlock =
                     """
                 EXPRESSION,                   EXPECTED_ERROR_MESSAGE
@@ -191,6 +169,28 @@ public class ConnectSelectorsSuppliersTest {
         assertThat(ve.getMessage()).isEqualTo(errorMessage);
     }
 
+    @ParameterizedTest(name = "[{index}] {arguments}")
+    @CsvSource(
+            useHeadersInDisplayName = true,
+            delimiter = '|', // Required because of the expected value for input VALUE.signature
+            textBlock =
+                    """
+                EXPRESSION     | EXPECTED
+                VALUE          | {"name":"joe","signature":"YWJjZA==","children":[],"nullArray":null}
+                VALUE.children | []
+                VALUE.name     | joe
+                    """)
+    public void shouldExtractValueWithNonScalars(String expression, String expected)
+            throws ExtractionException {
+        String text =
+                valueSelector(expression)
+                        .extractValue(
+                                sinkFromValue("topic", SIMPLE_STRUCT.schema(), SIMPLE_STRUCT),
+                                false)
+                        .text();
+        assertThat(text).isEqualTo(expected);
+    }
+
     @Test
     public void shouldNotExtractValueDueToMissingSchema() {
         ValueException ve =
@@ -200,6 +200,29 @@ public class ConnectSelectorsSuppliersTest {
                                 valueSelector("VALUE")
                                         .extractValue(sinkFromValue("topic", null, "a Value")));
         assertThat(ve.getMessage()).isEqualTo("A Schema is required");
+    }
+
+    @ParameterizedTest(name = "[{index}] {arguments}")
+    @CsvSource(
+            useHeadersInDisplayName = true,
+            textBlock =
+                    """
+                EXPRESSION,                  EXPECTED_ERROR_MESSAGE
+                VALUE.no_attrib,             Cannot retrieve field [no_attrib] from a null object
+                VALUE.children[0].no_attrib, Cannot retrieve field [children] from a null object
+                VALUE.no_children[0],        Cannot retrieve field [no_children] from a null object
+                    """)
+    public void shouldHandleNullValue(String expressionStr, String errorMessage)
+            throws ExtractionException {
+        ValueException ve =
+                assertThrows(
+                        ValueException.class,
+                        () ->
+                                valueSelector(expressionStr)
+                                        .extractValue(
+                                                sinkFromValue(
+                                                        "topic", SIMPLE_STRUCT.schema(), null)));
+        assertThat(ve.getMessage()).isEqualTo(errorMessage);
     }
 
     @ParameterizedTest(name = "[{index}] {arguments}")
@@ -237,27 +260,6 @@ public class ConnectSelectorsSuppliersTest {
     @ParameterizedTest(name = "[{index}] {arguments}")
     @CsvSource(
             useHeadersInDisplayName = true,
-            delimiter = '|', // Required because of the expected value for input VALUE.signature
-            textBlock =
-                    """
-                EXPRESSION   |  EXPECTED
-                KEY          |  {"name":"joe","signature":"YWJjZA==","children":[],"nullArray":null}
-                KEY.children |  []
-                KEY.name     |  joe
-                    """)
-    public void shouldExtractKeyWithNonScalars(String expression, String expected)
-            throws ExtractionException {
-        String text =
-                keySelector(expression)
-                        .extractKey(
-                                sinkFromKey("topic", SIMPLE_STRUCT.schema(), SIMPLE_STRUCT), false)
-                        .text();
-        assertThat(text).isEqualTo(expected);
-    }
-
-    @ParameterizedTest(name = "[{index}] {arguments}")
-    @CsvSource(
-            useHeadersInDisplayName = true,
             textBlock =
                     """
                 EXPRESSION,                 EXPECTED_ERROR_MESSAGE
@@ -283,6 +285,51 @@ public class ConnectSelectorsSuppliersTest {
                         () ->
                                 keySelector(expression)
                                         .extractKey(sinkFromKey("topic", STRUCT.schema(), STRUCT)));
+        assertThat(ve.getMessage()).isEqualTo(errorMessage);
+    }
+
+    @ParameterizedTest(name = "[{index}] {arguments}")
+    @CsvSource(
+            useHeadersInDisplayName = true,
+            delimiter = '|', // Required because of the expected value for input KEY.signature
+            textBlock =
+                    """
+                EXPRESSION   |  EXPECTED
+                KEY          |  {"name":"joe","signature":"YWJjZA==","children":[],"nullArray":null}
+                KEY.children |  []
+                KEY.name     |  joe
+                    """)
+    public void shouldExtractKeyWithNonScalars(String expression, String expected)
+            throws ExtractionException {
+        String text =
+                keySelector(expression)
+                        .extractKey(
+                                sinkFromKey("topic", SIMPLE_STRUCT.schema(), SIMPLE_STRUCT), false)
+                        .text();
+        assertThat(text).isEqualTo(expected);
+    }
+
+    @ParameterizedTest(name = "[{index}] {arguments}")
+    @CsvSource(
+            useHeadersInDisplayName = true,
+            delimiter = '|',
+            textBlock =
+                    """
+                EXPRESSION                | EXPECTED_ERROR_MESSAGE
+                KEY.no_attrib             | Cannot retrieve field [no_attrib] from a null object
+                KEY.children[0].no_attrib | Cannot retrieve field [children] from a null object
+                KEY.no_children[0]        | Cannot retrieve field [no_children] from a null object
+                    """)
+    public void shouldHandleNullKey(String expressionStr, String errorMessage)
+            throws ExtractionException {
+        ValueException ve =
+                assertThrows(
+                        ValueException.class,
+                        () ->
+                                keySelector(expressionStr)
+                                        .extractKey(
+                                                sinkFromKey(
+                                                        "topic", SIMPLE_STRUCT.schema(), null)));
         assertThat(ve.getMessage()).isEqualTo(errorMessage);
     }
 


### PR DESCRIPTION
This pull request fixes unexpected behaviors that occurred when processing Kafka records with null payloads. The changes include proper null handling for both keys and values, preventing exceptions during deserialization and ensuring consistent behavior across different record types.