### PR TITLE
Fix example/composte-templates/log4j.properties file

### DIFF
--- a/examples/compose-templates/log4j.properties
+++ b/examples/compose-templates/log4j.properties
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-log4j.logger.com.lightstreamer.kafka.adapters.pub.KafkaConnectorMetadataAdapter
+log4j.logger.com.lightstreamer.kafka.adapters.pub.KafkaConnectorMetadataAdapter=INFO, stdout
 log4j.logger.org.apache.kafka=WARN, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
Fix `examples/compose-templates/log4j.properties` file to explicitly set the logging level and output for the `KafkaConnectorMetadataAdapter` class. 