### PR TITLE
Fix subscribe/unsubscribe/subscribe race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,17 @@
 
 **Breaking Changes**
 
-- **Schema Registry Parameter Namespace**: Confluent Schema Registry-specific parameters previously under the `schema.registry` prefix have been moved to the `schema.registry.confluent` prefix. Update any existing configuration accordingly. ([#80](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/80))
+- **Schema Registry parameter namespace**: Confluent Schema Registry-specific parameters previously under the `schema.registry` prefix have been moved to the `schema.registry.confluent` prefix. Update any existing configuration accordingly. ([#80](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/80))
 
-- **Renamed Parameter**: `record.consume.max.poll.records` has been renamed to [`record.consume.with.max.poll.records`](README.md#recordconsumewithmaxpollrecords) for consistency with other `record.consume.with.*` parameters. ([#80](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/80))
+- **Renamed parameter**: `record.consume.max.poll.records` has been renamed to [`record.consume.with.max.poll.records`](README.md#recordconsumewithmaxpollrecords) for consistency with other `record.consume.with.*` parameters. ([#80](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/80))
 
 **Improvements**
 
-- **Azure Schema Registry Support**: Added native support for [_Azure Schema Registry_](README.md#azure-schema-registry-parameters) as a schema provider for both JSON and Avro message deserialization. Introduced the new [`schema.registry.provider`](README.md#schemaregistryprovider) parameter to select between `CONFLUENT` and `AZURE` as the Schema Registry provider. A dedicated [_Azure Event Hubs Quickstart_](examples/vendors/azure/quickstart-azure/) is also provided, including an advanced section covering [Azure Schema Registry integration](examples/vendors/azure/quickstart-azure/README.md#advanced-schema-registry-integration). ([#80](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/80))
+- **Azure Schema Registry support**: Added native support for [_Azure Schema Registry_](README.md#azure-schema-registry-parameters) as a schema provider for both JSON and Avro message deserialization. Introduced the new [`schema.registry.provider`](README.md#schemaregistryprovider) parameter to select between `CONFLUENT` and `AZURE` as the Schema Registry provider. A dedicated [_Azure Event Hubs Quickstart_](examples/vendors/azure/quickstart-azure/) is also provided, including an advanced section covering [Azure Schema Registry integration](examples/vendors/azure/quickstart-azure/README.md#advanced-schema-registry-integration). ([#80](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/80))
 
-- **Configurable Session Timeout**: Exposed the [`record.consume.with.session.timeout.ms`](README.md#recordconsumewithsessiontimeoutms) parameter to configure the timeout used to detect client failures when using Kafka's group management facility. ([#80](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/80))
+- **Configurable session timeout**: Exposed the [`record.consume.with.session.timeout.ms`](README.md#recordconsumewithsessiontimeoutms) parameter to configure the timeout used to detect client failures when using Kafka's group management facility. ([#80](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/80))
 
-- **Configurable Max Poll Interval**: Exposed the [`record.consume.with.max.poll.interval.ms`](README.md#recordconsumewithmaxpollintervalms) parameter to configure the maximum delay between invocations of `poll()` when using consumer group management. ([#80](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/80))
+- **Configurable max poll interval**: Exposed the [`record.consume.with.max.poll.interval.ms`](README.md#recordconsumewithmaxpollintervalms) parameter to configure the maximum delay between invocations of `poll()` when using consumer group management. ([#80](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/80))
 
 **Examples and Documentation**
 
@@ -35,9 +35,9 @@
 
 **Improvements**
 
-- **Official Docker Image**: Introduced official Docker images published to GitHub Container Registry (`ghcr.io/lightstreamer/lightstreamer-kafka-connector`), with automated builds via GitHub Actions on each release. Moved Docker resources from `examples/docker` to the new `/docker` folder with production-ready build scripts and Dockerfile. ([#77](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/77))
+- **Official Docker image**: Introduced official Docker images published to GitHub Container Registry (`ghcr.io/lightstreamer/lightstreamer-kafka-connector`), with automated builds via GitHub Actions on each release. Moved Docker resources from `examples/docker` to the new `/docker` folder with production-ready build scripts and Dockerfile. ([#77](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/77))
 
-- **Absolute Path Support**: Extended file path configuration parameters (such as `logging.configuration.path`, `encryption.truststore.path`, `encryption.keystore.path`, `authentication.gssapi.key.tab.path`, and `record.*.evaluator.schema.path`) to also accept absolute paths, in addition to paths relative to the deployment folder. Updated the factory [`adapters.xml`](kafka-connector-project/kafka-connector/src/adapter/dist/adapters.xml) and [`README.md`](README.md) files accordingly. ([#79](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/79))
+- **Absolute path support**: Extended file path configuration parameters (such as `logging.configuration.path`, `encryption.truststore.path`, `encryption.keystore.path`, `authentication.gssapi.key.tab.path`, and `record.*.evaluator.schema.path`) to also accept absolute paths, in addition to paths relative to the deployment folder. Updated the factory [`adapters.xml`](kafka-connector-project/kafka-connector/src/adapter/dist/adapters.xml) and [`README.md`](README.md) files accordingly. ([#79](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/79))
 
 **Examples and Documentation**
 
@@ -52,13 +52,13 @@
 
 **Improvements**
 
-- **Polling Lifecycle Optimization**: Significantly enhanced the polling lifecycle to improve throughput and minimize record lag. Introduced an adaptive commit strategy that dynamically adjusts commit frequency based on message rate. This optimization also removes previous constraints that prevented concurrent processing when using compacted topics. ([#76](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/76))
+- **Polling lifecycle optimization**: Significantly enhanced the polling lifecycle to improve throughput and minimize record lag. Introduced an adaptive commit strategy that dynamically adjusts commit frequency based on message rate. This optimization also removes previous constraints that prevented concurrent processing when using compacted topics. ([#76](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/76))
 
-- **Monitor Logger**: Added a dedicated logger to track essential performance metrics including records received, records processed, and internal ring buffer utilization rates. ([#76](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/76))
+- **Monitor logger**: Added a dedicated logger to track essential performance metrics including records received, records processed, and internal ring buffer utilization rates. ([#76](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/76))
 
-- **Configurable Max Poll Records**: Exposed the [`record.consume.max.poll.records`](README.md#recordconsumemaxpollrecords) parameter to configure the maximum number of records fetched in each polling cycle of the internal Kafka consumer. ([#76](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/76))
+- **Configurable max poll records**: Exposed the [`record.consume.max.poll.records`](README.md#recordconsumemaxpollrecords) parameter to configure the maximum number of records fetched in each polling cycle of the internal Kafka consumer. ([#76](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/76))
 
-- **Microbenchmarks Consolidation**: Refactored and consolidated the internal microbenchmarking suite to improve performance testing capabilities. ([#76](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/76))
+- **Microbenchmarks consolidation**: Refactored and consolidated the internal microbenchmarking suite to improve performance testing capabilities. ([#76](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/76))
 
 **Examples and Documentation**
 
@@ -89,9 +89,9 @@
 
 **Improvements**
 
-- **Deferred Deserialization**: Refactored the deserialization pipeline to defer the conversion of raw bytes to deserialized objects. This architectural change makes the Kafka Connector open for further extension by allowing custom implementations to intercept and access raw bytes from Kafka records before or instead of automatic deserialization. ([#75](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/75))
+- **Deferred deserialization**: Refactored the deserialization pipeline to defer the conversion of raw bytes to deserialized objects. This architectural change makes the Kafka Connector open for further extension by allowing custom implementations to intercept and access raw bytes from Kafka records before or instead of automatic deserialization. ([#75](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/75))
 
-- **Auto COMMAND Mode**: Added support for the [Auto COMMAND mode](README.md#auto-command-mode-fieldsautocommandmodeenable) feature that generates _command_ operations for Lightstreamer items without requiring explicit command fields in the Kafka records. ([#75](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/75))
+- **Auto COMMAND mode**: Added support for the [Auto COMMAND mode](README.md#auto-command-mode-fieldsautocommandmodeenable) feature that generates _command_ operations for Lightstreamer items without requiring explicit command fields in the Kafka records. ([#75](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/75))
 
 - Consolidated the script for running microbenchmarks. ([#75](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/75))
 
@@ -99,14 +99,14 @@
 
 **Bug Fixes**
 
-- **Null Value Deserialization**: Fixed incorrect handling of null values during deserialization when using ProtoBuf, JSON, and Avro formats. The deserializers now properly process null payloads without triggering unexpected errors or data loss. ([#75](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/75))
+- **Null value deserialization**: Fixed incorrect handling of null values during deserialization when using ProtoBuf, JSON, and Avro formats. The deserializers now properly process null payloads without triggering unexpected errors or data loss. ([#75](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/75))
 
 
 ## [1.3.1] (2025-12-19)
 
 **Improvements**
 
-- **Data Extraction Language Enhancement and Dynamic Field Discovery**: Extended the [_Data Extraction Language_](README.md#data-extraction-language) to support wildcard expressions (e.g., `#{VALUE.*}`, `#{KEY.*}`, `#{HEADERS.*}`), enabling the new [_Dynamic Field Discovery_](README.md#dynamic-field-discovery-field) mechanism with the `field.*` configuration parameter. This allows automatic mapping of Kafka record fields to Lightstreamer fields at runtime, eliminating the need to explicitly configure each field individually – especially useful for records with numerous or dynamically varying fields (also available for the Sink connector). ([#72](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/72))
+- **Data Extraction Language enhancement and dynamic field discovery**: Extended the [_Data Extraction Language_](README.md#data-extraction-language) to support wildcard expressions (e.g., `#{VALUE.*}`, `#{KEY.*}`, `#{HEADERS.*}`), enabling the new [_Dynamic Field Discovery_](README.md#dynamic-field-discovery-field) mechanism with the `field.*` configuration parameter. This allows automatic mapping of Kafka record fields to Lightstreamer fields at runtime, eliminating the need to explicitly configure each field individually – especially useful for records with numerous or dynamically varying fields (also available for the Sink connector). ([#72](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/72))
 
 - Upgraded _Gradle_ to version 9.2.1. ([#72](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/72))
 
@@ -126,33 +126,33 @@
 
 **Breaking Changes**
 
-- **KafkaConnectorMetadataAdapter Class Hierarchy Change**: The [`com.lightstreamer.kafka.adapters.pub.KafkaConnectorMetadataAdapter`](https://lightstreamer.github.io/Lightstreamer-kafka-connector/javadoc/com/lightstreamer/kafka/adapters/pub/KafkaConnectorMetadataAdapter.html) class now extends [`com.lightstreamer.adapters.metadata.MetadataProviderAdapter`](https://sdk.lightstreamer.com/ls-adapter-inprocess/8.0.0/api/com/lightstreamer/interfaces/metadata/MetadataProviderAdapter.html) directly instead of [`com.lightstreamer.adapters.metadata.LiteralBasedProvider`](https://sdk.lightstreamer.com/ls-adapter-inprocess/8.0.0/api/com/lightstreamer/adapters/metadata/LiteralBasedProvider.html). This change affects any custom implementations that relied on `com.lightstreamer.adapters.metadata.LiteralBasedProvider`-specific functionality. Additionally, a new [`remapItems`](https://lightstreamer.github.io/Lightstreamer-kafka-connector/javadoc/com/lightstreamer/kafka/adapters/pub/KafkaConnectorMetadataAdapter.html#remapItems(java.lang.String,java.lang.String,java.lang.String,java.lang.String))  method has been introduced that provides a hook for custom item resolution logic. Custom metadata adapters extending `com.lightstreamer.kafka.adapters.pub.KafkaConnectorMetadataAdapter` should override the new `remapItems` method to provide custom item resolution logic, rather than overriding [`getItems`](https://sdk.lightstreamer.com/ls-adapter-inprocess/8.0.0/api/com/lightstreamer/interfaces/metadata/MetadataProvider.html#getItems(java.lang.String,java.lang.String,java.lang.String,java.lang.String)) directly. Other methods that were previously provided by [`com.lightstreamer.adapters.metadata.LiteralBasedProvider`](https://sdk.lightstreamer.com/ls-adapter-inprocess/8.0.0/api/com/lightstreamer/adapters/metadata/LiteralBasedProvider.html), such as [`getSchema`](https://sdk.lightstreamer.com/ls-adapter-inprocess/8.0.0/api/com/lightstreamer/interfaces/metadata/MetadataProvider.html#getSchema(java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String)) and other metadata resolution methods, may also need to be implemented. ([#71](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/71))
+- **KafkaConnectorMetadataAdapter class hierarchy change**: The [`com.lightstreamer.kafka.adapters.pub.KafkaConnectorMetadataAdapter`](https://lightstreamer.github.io/Lightstreamer-kafka-connector/javadoc/com/lightstreamer/kafka/adapters/pub/KafkaConnectorMetadataAdapter.html) class now extends [`com.lightstreamer.adapters.metadata.MetadataProviderAdapter`](https://sdk.lightstreamer.com/ls-adapter-inprocess/8.0.0/api/com/lightstreamer/interfaces/metadata/MetadataProviderAdapter.html) directly instead of [`com.lightstreamer.adapters.metadata.LiteralBasedProvider`](https://sdk.lightstreamer.com/ls-adapter-inprocess/8.0.0/api/com/lightstreamer/adapters/metadata/LiteralBasedProvider.html). This change affects any custom implementations that relied on `com.lightstreamer.adapters.metadata.LiteralBasedProvider`-specific functionality. Additionally, a new [`remapItems`](https://lightstreamer.github.io/Lightstreamer-kafka-connector/javadoc/com/lightstreamer/kafka/adapters/pub/KafkaConnectorMetadataAdapter.html#remapItems(java.lang.String,java.lang.String,java.lang.String,java.lang.String))  method has been introduced that provides a hook for custom item resolution logic. Custom metadata adapters extending `com.lightstreamer.kafka.adapters.pub.KafkaConnectorMetadataAdapter` should override the new `remapItems` method to provide custom item resolution logic, rather than overriding [`getItems`](https://sdk.lightstreamer.com/ls-adapter-inprocess/8.0.0/api/com/lightstreamer/interfaces/metadata/MetadataProvider.html#getItems(java.lang.String,java.lang.String,java.lang.String,java.lang.String)) directly. Other methods that were previously provided by [`com.lightstreamer.adapters.metadata.LiteralBasedProvider`](https://sdk.lightstreamer.com/ls-adapter-inprocess/8.0.0/api/com/lightstreamer/adapters/metadata/LiteralBasedProvider.html), such as [`getSchema`](https://sdk.lightstreamer.com/ls-adapter-inprocess/8.0.0/api/com/lightstreamer/interfaces/metadata/MetadataProvider.html#getSchema(java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String)) and other metadata resolution methods, may also need to be implemented. ([#71](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/71))
 
 **Improvements**
 
-- **Core Algorithm Optimizations**: Enhanced overall system performance through optimizations in data processing, record mapping, and routing logic. These improvements result in faster record processing and reduced resource consumption during high-throughput scenarios. ([#71](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/71))
+- **Core algorithm optimizations**: Enhanced overall system performance through optimizations in data processing, record mapping, and routing logic. These improvements result in faster record processing and reduced resource consumption during high-throughput scenarios. ([#71](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/71))
 
-- **Data Access Pattern Optimization**: Optimized record routing algorithm to use more efficient data access patterns, improving throughput when delivering messages to multiple subscribed clients. ([#71](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/71))
+- **Data access pattern optimization**: Optimized record routing algorithm to use more efficient data access patterns, improving throughput when delivering messages to multiple subscribed clients. ([#71](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/71))
 
-- **Comprehensive Benchmarking Suite**: Added comprehensive performance benchmarking infrastructure to enable systematic performance monitoring and optimization of core components including data extraction, record mapping, and expression evaluation. ([#71](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/71))
+- **Comprehensive benchmarking suite**: Added comprehensive performance benchmarking infrastructure to enable systematic performance monitoring and optimization of core components including data extraction, record mapping, and expression evaluation. ([#71](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/71))
 
-- **Improved Logging**: Refined logging levels to reduce verbosity in production environments while maintaining debugging capabilities when needed. ([#71](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/71))
+- **Improved logging**: Refined logging levels to reduce verbosity in production environments while maintaining debugging capabilities when needed. ([#71](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/71))
 
 **Bug Fixes**
 
-- **Consumer Shutdown Robustness**: Enhanced error handling during Kafka consumer shutdown to prevent hanging or incomplete disconnections. ([#71](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/71))
+- **Consumer shutdown robustness**: Enhanced error handling during Kafka consumer shutdown to prevent hanging or incomplete disconnections. ([#71](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/71))
 
-- **Configuration Cleanup**: Removed `group.id` assignment from the factory [`adapters.xml`](kafka-connector-project/kafka-connector/src/adapter/dist/adapters.xml) file. ([#71](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/71))
+- **Configuration cleanup**: Removed `group.id` assignment from the factory [`adapters.xml`](kafka-connector-project/kafka-connector/src/adapter/dist/adapters.xml) file. ([#71](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/71))
 
-- **Protobuf Deserialization**: Improved robustness of Protobuf message deserialization by ensuring that the specified message type exists in the provided schema file. ([#70](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/70))
+- **Protobuf deserialization**: Improved robustness of Protobuf message deserialization by ensuring that the specified message type exists in the provided schema file. ([#70](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/70))
 
 **Code Quality Improvements**
 
-- **Import Organization**: Cleaned up unused imports across multiple files. ([#71](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/71))
+- **Import organization**: Cleaned up unused imports across multiple files. ([#71](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/71))
 
-- **Documentation Enhancement**: Improved inline documentation and method signatures. ([#71](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/71))
+- **Documentation enhancement**: Improved inline documentation and method signatures. ([#71](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/71))
 
-- **Code Structure**: Removed commented-out code and unnecessary blank lines for cleaner codebase. ([#71](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/71))
+- **Code structure**: Removed commented-out code and unnecessary blank lines for cleaner codebase. ([#71](https://github.com/Lightstreamer/Lightstreamer-kafka-connector/pull/71))
 
 
 ## [1.2.10] (2025-09-18)

--- a/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/adapters/consumers/SubscriptionsHandler.java
+++ b/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/adapters/consumers/SubscriptionsHandler.java
@@ -155,26 +155,29 @@ public interface SubscriptionsHandler<K, V> {
                 subscribedItems.addItem(newItem);
                 newItem.enableRealtimeEvents(this.eventListener);
 
-                onSubscribedItem(newItem);
+                onItemSubscribed(newItem);
             } catch (ExpressionException e) {
                 logger.atError().setCause(e).log();
                 throw new SubscriptionException(e.getMessage());
             }
         }
 
-        final FutureStatus startConsuming(boolean waitForInit) throws KafkaException {
+        final FutureStatus startConsuming() throws KafkaException {
             logger.atTrace().log("Acquiring consumer lock to start consuming events...");
             consumerLock.lock();
-            logger.atTrace().log("Lock acquired...");
+            logger.atTrace().log("Consumer lock acquired...");
             try {
                 if (consumer == null) {
                     logger.atInfo().log("Consumer not yet initialized, creating a new one...");
-                    consumer = newConsumer();
+                    consumer = newConsumer(); // May throw KafkaException
                     logger.atInfo().log("New consumer connecting and subscribing...");
-                    futureStatus = consumer.startLoop(pool, waitForInit);
+                    futureStatus = consumer.startLoop(pool);
                 } else {
                     logger.atDebug().log("Consumer is already consuming events, nothing to do");
                 }
+            } catch (KafkaException ke) {
+                logger.atError().setCause(ke).log("Unable to connect to Kafka");
+                metadataListener.forceUnsubscriptionAll();
             } finally {
                 logger.atTrace().log("Releasing consumer lock...");
                 consumerLock.unlock();
@@ -187,7 +190,7 @@ public interface SubscriptionsHandler<K, V> {
         public final Optional<SubscribedItem> unsubscribe(String item) {
             Optional<SubscribedItem> removedItem = subscribedItems.removeItem(item);
             if (removedItem.isPresent()) {
-                onUnsubscribedItem();
+                onItemUnsubscribed(removedItem.get());
             }
 
             return removedItem;
@@ -196,7 +199,7 @@ public interface SubscriptionsHandler<K, V> {
         final void stopConsuming() {
             logger.atTrace().log("Acquiring consumer lock to stop consuming...");
             consumerLock.lock();
-            logger.atTrace().log("Lock acquired to stop consuming...");
+            logger.atTrace().log("Consumer lock acquired to stop consuming...");
             try {
                 if (consumer != null) {
                     logger.atInfo().log("Stopping consumer...");
@@ -208,9 +211,9 @@ public interface SubscriptionsHandler<K, V> {
                     logger.atDebug().log("Consumer is not initialized yet, nothing to do");
                 }
             } finally {
-                logger.atTrace().log("Releasing consumer lock to stop consuming");
+                logger.atTrace().log("Releasing consumer lock...");
                 consumerLock.unlock();
-                logger.atTrace().log("Releases consumer lock to stop consuming");
+                logger.atTrace().log("Consumer lock released");
             }
         }
 
@@ -230,7 +233,7 @@ public interface SubscriptionsHandler<K, V> {
 
         void onItemEventListenerSet() {}
 
-        void onSubscribedItem(SubscribedItem item) {}
+        void onItemSubscribed(SubscribedItem item) {}
 
         KafkaConsumerWrapper<K, V> newConsumer() throws KafkaException {
             if (eventListener == null) {
@@ -241,7 +244,7 @@ public interface SubscriptionsHandler<K, V> {
                     config, metadataListener, eventListener, subscribedItems, consumerSupplier);
         }
 
-        void onUnsubscribedItem() {}
+        void onItemUnsubscribed(SubscribedItem item) {}
 
         // Only for testing purposes
         SubscribedItems getSubscribedItems() {
@@ -263,20 +266,15 @@ public interface SubscriptionsHandler<K, V> {
         }
 
         @Override
-        void onSubscribedItem(SubscribedItem item) {
+        void onItemSubscribed(SubscribedItem item) {
             if (itemsCounter.incrementAndGet() == 1) {
-                try {
-                    startConsuming(false);
-                    // consumer.consumeRecordsAsSnapshot(null, item);
-                } catch (KafkaException ke) {
-                    logger.atError().setCause(ke).log("Unable to connect to Kafka");
-                    metadataListener.forceUnsubscriptionAll();
-                }
+                startConsuming();
+                // consumer.consumeRecordsAsSnapshot(null, item);
             }
         }
 
         @Override
-        void onUnsubscribedItem() {
+        void onItemUnsubscribed(SubscribedItem item) {
             if (itemsCounter.decrementAndGet() == 0) {
                 stopConsuming();
             }

--- a/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/adapters/consumers/wrapper/KafkaConsumerWrapper.java
+++ b/kafka-connector-project/kafka-connector/src/main/java/com/lightstreamer/kafka/adapters/consumers/wrapper/KafkaConsumerWrapper.java
@@ -278,14 +278,6 @@ public class KafkaConsumerWrapper<K, V> {
                         config.suppliers().keySelectorSupplier().deserializer(),
                         config.suppliers().valueSelectorSupplier().deserializer());
         this.deserializationMode = new EagerDeserializationMode<>(deserializers);
-        // this.deserializationMode = new DeferredDeserializationMode<>(deserializers);
-        // this.deserializationMode =
-        //         recordConsumer.isParallel()
-        //                 ? new DeferredDeserializationMode<>(deserializers)
-        //                 : new EagerDeserializationMode<>(deserializers);
-
-        // ((AbstractRecordConsumer<K, V>) this.recordConsumer)
-        //         .setDeserializationMode(deserializationMode);
         logger.atInfo().log("Using {} record deserialization", deserializationMode.getTiming());
     }
 
@@ -300,7 +292,7 @@ public class KafkaConsumerWrapper<K, V> {
         return this.config.consumerProperties().getProperty(key);
     }
 
-    public FutureStatus startLoop(ExecutorService pool, boolean waitForInit) {
+    public FutureStatus startLoop(ExecutorService pool) {
         statusLock.lock();
         try {
             if (!status.isConnected()) {
@@ -309,21 +301,16 @@ public class KafkaConsumerWrapper<K, V> {
                 return status;
             }
 
-            CompletableFuture<FutureStatus.State> initStage =
-                    CompletableFuture.supplyAsync(this::init, pool);
-            if (waitForInit) {
-                logger.atDebug().log("Blocking until initialization completes");
-                State state = initStage.join();
-                logger.atDebug().log("Initialization completed");
-                if (state.initFailed()) {
-                    // In case of failure, immediately return a failed status.
-                    // This is mandatory for use cases where the initialization must be
-                    // completed before starting the loop.
-                    return updateStatus(initStage);
-                }
+            logger.atDebug().log("Starting initialization");
+            State state = this.init();
+            logger.atDebug().log("Initialization completed with state: {}", state);
+
+            if (state.initFailed()) {
+                // In case of failure, immediately return a failed status.
+                return updateStatus(CompletableFuture.completedFuture(state));
             }
 
-            return updateStatus(initStage.thenApplyAsync(this::runLoop, pool));
+            return updateStatus(CompletableFuture.supplyAsync(this::runLoop, pool));
         } finally {
             statusLock.unlock();
         }
@@ -334,25 +321,36 @@ public class KafkaConsumerWrapper<K, V> {
         return status;
     }
 
-    private FutureStatus.State init() {
-        if (!subscribed()) {
-            logger.atWarn().log("Initialization failed because no topics are subscribed");
-            closeConsumer();
-            metadataListener.forceUnsubscriptionAll();
-            return FutureStatus.State.INIT_FAILED_BY_SUBSCRIPTION;
-        }
-
-        this.monitor.start(MONITOR_LOG_REPORTING_INTERVAL);
+    private State init() {
+        State state;
 
         try {
-            pollOnce(this::initStoreAndConsume);
+            if (subscribed()) {
+                this.monitor.start(MONITOR_LOG_REPORTING_INTERVAL);
+                pollOnce(this::initStoreAndConsume);
+                state = State.INITIALIZED;
+            } else {
+                logger.atWarn().log("Initialization failed because no topics are subscribed");
+                state = State.INIT_FAILED_BY_SUBSCRIPTION;
+            }
         } catch (KafkaException e) {
-            logger.atWarn().log("Initialization failed because of an exception");
-            closeConsumer();
-            metadataListener.forceUnsubscriptionAll();
-            return FutureStatus.State.INIT_FAILED_BY_EXCEPTION;
+            logger.atWarn().setCause(e).log("Initialization failed because of an exception");
+            state = State.INIT_FAILED_BY_EXCEPTION;
+        } catch (RuntimeException e) {
+            logger.atWarn()
+                    .setCause(e)
+                    .log("Initialization failed because of an unexpected exception");
+            state = State.INIT_FAILED_BY_EXCEPTION;
         }
-        return FutureStatus.State.INITIALIZED;
+
+        if (state.initFailed()) {
+            closeConsumer();
+            // forceUnsubscriptionAll is idempotent, so calling it here is safe even if already
+            // invoked in the doPoll catch blocks.
+            metadataListener.forceUnsubscriptionAll();
+        }
+
+        return state;
     }
 
     private void installShutdownHook() {
@@ -379,37 +377,32 @@ public class KafkaConsumerWrapper<K, V> {
         logger.atDebug().log("Checking existing topics on Kafka");
 
         // Check the actual available topics on Kafka.
-        try {
-            Map<String, List<PartitionInfo>> listTopics =
-                    consumer.listTopics(Duration.ofMillis(30000));
+        Map<String, List<PartitionInfo>> listTopics = consumer.listTopics(Duration.ofMillis(30000));
 
-            // Retain from the original requests topics the available ones.
-            Set<String> existingTopics = listTopics.keySet();
-            boolean notAllPresent = topics.retainAll(existingTopics);
+        // Retain from the original requests topics the available ones.
+        Set<String> existingTopics = listTopics.keySet();
+        logger.atDebug().log("Existing topics on Kafka: [{}]", existingTopics);
+        boolean notAllPresent = topics.retainAll(existingTopics);
 
-            // Can't subscribe at all. Force unsubscription and exit the loop.
-            if (topics.isEmpty()) {
-                logger.atWarn().log("Requested topics not found");
-                return false;
-            }
-
-            // Just warn that not all requested topics can be subscribed.
-            if (notAllPresent) {
-                String loggableTopics =
-                        topics.stream()
-                                .map(s -> "\"%s\"".formatted(s))
-                                .collect(Collectors.joining(","));
-                logger.atWarn()
-                        .log(
-                                "Actually subscribing to the following existing topics [{}]",
-                                loggableTopics);
-            }
-            consumer.subscribe(topics, offsetService);
-            return true;
-        } catch (Exception e) {
-            logger.atError().setCause(e).log();
+        // Can't subscribe at all. Force unsubscription and exit the loop.
+        if (topics.isEmpty()) {
+            logger.atWarn().log("Requested topics not found");
             return false;
         }
+
+        // Just warn that not all requested topics can be subscribed.
+        if (notAllPresent) {
+            String loggableTopics =
+                    topics.stream()
+                            .map(s -> "\"%s\"".formatted(s))
+                            .collect(Collectors.joining(","));
+            logger.atWarn()
+                    .log(
+                            "Actually subscribing to the following existing topics [{}]",
+                            loggableTopics);
+        }
+        consumer.subscribe(topics, offsetService);
+        return true;
     }
 
     void pollOnce(java.util.function.Consumer<RecordBatch<K, V>> batchConsumer)
@@ -434,7 +427,7 @@ public class KafkaConsumerWrapper<K, V> {
         } catch (KafkaException ke) {
             // Includes SerializationException (a KafkaException subclass) thrown during eager
             // deserialization: treated as fatal, causing connector shutdown
-            logger.atError().setCause(ke).log("Unrecoverable exception");
+            logger.atError().setCause(ke).log("Unrecoverable exception during poll");
             metadataListener.forceUnsubscriptionAll();
             throw ke;
         } catch (Exception e) {
@@ -456,12 +449,7 @@ public class KafkaConsumerWrapper<K, V> {
         logger.atDebug().log("Kafka Consumer closed");
     }
 
-    private FutureStatus.State runLoop(State previousState) {
-        if (previousState.initFailed()) {
-            logger.atError().log("Failed state, no records will be consumed");
-            return previousState;
-        }
-
+    private State runLoop() {
         // Install the shutdown hook
         installShutdownHook();
         logger.atDebug().log("Shutdown hook set");
@@ -471,11 +459,11 @@ public class KafkaConsumerWrapper<K, V> {
             logger.atDebug().log("Kafka Consumer woken up");
         } catch (KafkaException e) {
             logger.atError().setCause(e).log("Unrecoverable exception during polling");
-            return FutureStatus.State.LOOP_CLOSED_BY_EXCEPTION;
+            return State.LOOP_CLOSED_BY_EXCEPTION;
         } finally {
             closeConsumer();
         }
-        return FutureStatus.State.LOOP_CLOSED_BY_WAKEUP;
+        return State.LOOP_CLOSED_BY_WAKEUP;
     }
 
     void runPollingLoop(java.util.function.Consumer<RecordBatch<K, V>> recordConsumer)
@@ -512,7 +500,7 @@ public class KafkaConsumerWrapper<K, V> {
                 Runtime.getRuntime().removeShutdownHook(this.hook);
                 this.hook = null;
             }
-            return updateStatus(CompletableFuture.completedFuture(FutureStatus.State.SHUTDOWN));
+            return updateStatus(CompletableFuture.completedFuture(State.SHUTDOWN));
         } finally {
             statusLock.unlock();
         }

--- a/kafka-connector-project/kafka-connector/src/test/java/com/lightstreamer/kafka/adapters/consumers/DefaultSubscriptionsHandlerTest.java
+++ b/kafka-connector-project/kafka-connector/src/test/java/com/lightstreamer/kafka/adapters/consumers/DefaultSubscriptionsHandlerTest.java
@@ -50,6 +50,7 @@ import org.junit.jupiter.api.Timeout;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -58,10 +59,15 @@ public class DefaultSubscriptionsHandlerTest {
     private MockMetadataListener metadataListener = new Mocks.MockMetadataListener();
 
     private DefaultSubscriptionsHandler<String, String> mkSubscriptionsHandler(
-            boolean exceptionOnConnection, String... topics) {
+            boolean exceptionOnConnection,
+            boolean exceptionOnListTopics,
+            boolean exceptionOnPoll,
+            String... topics) {
 
         Properties properties = new Properties();
         properties.setProperty(AUTO_OFFSET_RESET_CONFIG, "earliest");
+        properties.setProperty("bootstrap.servers", "localhost:9092");
+
         Config<String, String> config =
                 new Config<>(
                         "TestConnection",
@@ -74,16 +80,24 @@ public class DefaultSubscriptionsHandlerTest {
                         CommandModeStrategy.NONE,
                         new Concurrency(RecordConsumeWithOrderStrategy.ORDER_BY_PARTITION, 1));
 
-        MockConsumer consumer = new MockConsumer(StrategyType.EARLIEST.toString());
-        for (String topic : topics) {
-            consumer.updatePartitions(
-                    topic, List.of(new PartitionInfo(topic, 0, null, null, null)));
-        }
-
         Supplier<Consumer<byte[], byte[]>> supplier =
                 () -> {
                     if (exceptionOnConnection) {
                         throw new KafkaException("Simulated Exception");
+                    }
+
+                    MockConsumer consumer = new MockConsumer(StrategyType.EARLIEST.toString());
+                    if (exceptionOnListTopics) {
+                        consumer.setListTopicException(new KafkaException("Simulated Exception"));
+                    }
+
+                    if (exceptionOnPoll) {
+                        consumer.setPollException(new KafkaException("Simulated Exception"));
+                    }
+
+                    for (String topic : topics) {
+                        consumer.updatePartitions(
+                                topic, List.of(new PartitionInfo(topic, 0, null, null, null)));
                     }
                     return consumer;
                 };
@@ -101,11 +115,17 @@ public class DefaultSubscriptionsHandlerTest {
     private MockItemEventListener listener = new MockItemEventListener();
 
     void init(String... topics) {
-        init(false, topics);
+        init(false, false, false, topics);
     }
 
-    void init(boolean exceptionOnConnection, String... topics) {
-        this.subscriptionHandler = mkSubscriptionsHandler(exceptionOnConnection, topics);
+    void init(
+            boolean exceptionOnConnection,
+            boolean exceptionOnListTopics,
+            boolean exceptionOnPoll,
+            String... topics) {
+        this.subscriptionHandler =
+                mkSubscriptionsHandler(
+                        exceptionOnConnection, exceptionOnListTopics, exceptionOnPoll, topics);
         this.subscriptionHandler.setListener(listener);
         this.subscribedItems = subscriptionHandler.getSubscribedItems();
     }
@@ -121,7 +141,7 @@ public class DefaultSubscriptionsHandlerTest {
     }
 
     @Test
-    public void shouldSubscribe() throws SubscriptionException {
+    public void shouldSubscribe() throws SubscriptionException, InterruptedException {
         init("aTopic");
 
         Object itemHandle1 = new Object();
@@ -179,10 +199,41 @@ public class DefaultSubscriptionsHandlerTest {
     }
 
     @Test
-    @Timeout(value = 1, unit = TimeUnit.SECONDS, threadMode = SEPARATE_THREAD)
+    public void shouldForceUnsubscriptionDueToExceptionWhileGettingTopicList()
+            throws SubscriptionException {
+        init(false, true, false, "aTopic");
+        Object itemHandle = new Object();
+        subscriptionHandler.subscribe("anItemTemplate", itemHandle);
+
+        // Removal of subscribed item actual happens in the unsubscribe method
+        // invoked by the Kernel following the forced unsubscription
+        assertThat(subscriptionHandler.getItemsCounter()).isEqualTo(1);
+        assertThat(subscriptionHandler.getSubscribedItems().size()).isEqualTo(1);
+
+        assertThat(subscriptionHandler.isConsuming()).isFalse();
+        assertThat(metadataListener.forcedUnsubscription()).isTrue();
+    }
+
+    @Test
     public void shouldForceUnsubscriptionDueToExceptionWhileConnecting()
             throws SubscriptionException {
-        init(true);
+        init(true, false, false);
+        Object itemHandle = new Object();
+        subscriptionHandler.subscribe("anItemTemplate", itemHandle);
+
+        // Removal of subscribed item actual happens in the unsubscribe method
+        // invoked by the Kernel following the forced unsubscription
+        assertThat(subscriptionHandler.getItemsCounter()).isEqualTo(1);
+        assertThat(subscriptionHandler.getSubscribedItems().size()).isEqualTo(1);
+
+        assertThat(subscriptionHandler.isConsuming()).isFalse();
+        assertThat(metadataListener.forcedUnsubscription()).isTrue();
+    }
+
+    @Test
+    public void shouldForceUnsubscriptionDueToExceptionWhileFirstPoll()
+            throws SubscriptionException {
+        init(false, false, true, "aTopic");
         Object itemHandle = new Object();
         subscriptionHandler.subscribe("anItemTemplate", itemHandle);
 
@@ -212,15 +263,17 @@ public class DefaultSubscriptionsHandlerTest {
 
     @Test
     public void shouldUnsubscribe() throws SubscriptionException {
-        init();
+        init("aTopic");
         Object itemHandle1 = new Object();
         Object itemHandle2 = new Object();
 
         subscriptionHandler.subscribe("anItemTemplate", itemHandle1);
         SubscribedItem item1 = subscribedItems.getItem("anItemTemplate");
+        assertThat(subscriptionHandler.isConsuming()).isTrue();
 
         subscriptionHandler.subscribe("anotherItemTemplate", itemHandle2);
         SubscribedItem item2 = subscribedItems.getItem("anotherItemTemplate");
+        assertThat(subscriptionHandler.isConsuming()).isTrue();
 
         Optional<SubscribedItem> removed1 = subscriptionHandler.unsubscribe("anItemTemplate");
         assertThat(subscriptionHandler.getItemsCounter()).isEqualTo(1);
@@ -242,5 +295,29 @@ public class DefaultSubscriptionsHandlerTest {
 
         Optional<SubscribedItem> unsubscribed = subscriptionHandler.unsubscribe("anItemTemplate");
         assertThat(unsubscribed).isEmpty();
+    }
+
+    @Test
+    public void shouldHandleSubscriptionBeforeShutdownCompletes()
+            throws SubscriptionException, InterruptedException {
+        init("aTopic");
+
+        Object itemHandle = new Object();
+        subscriptionHandler.subscribe("anItemTemplate", itemHandle);
+        TimeUnit.MILLISECONDS.sleep(50);
+        assertThat(subscriptionHandler.isConsuming()).isTrue();
+
+        subscriptionHandler.unsubscribe("anItemTemplate");
+        CompletableFuture<Void> thread =
+                CompletableFuture.runAsync(
+                        () -> {
+                            try {
+                                subscriptionHandler.subscribe("anotherItemTemplate", itemHandle);
+                            } catch (SubscriptionException e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+        thread.join();
+        assertThat(subscriptionHandler.isConsuming()).isTrue();
     }
 }

--- a/kafka-connector-project/kafka-connector/src/test/java/com/lightstreamer/kafka/adapters/consumers/wrapper/KafkaConsumerWrapperTest.java
+++ b/kafka-connector-project/kafka-connector/src/test/java/com/lightstreamer/kafka/adapters/consumers/wrapper/KafkaConsumerWrapperTest.java
@@ -661,7 +661,7 @@ public class KafkaConsumerWrapperTest {
         mockConsumer.scheduleNopPollTask();
 
         // Run the consumer for at least 1 second
-        FutureStatus awaitClose = wrapper.startLoop(Executors.newSingleThreadExecutor(), false);
+        FutureStatus awaitClose = wrapper.startLoop(Executors.newSingleThreadExecutor());
         assertThat(awaitClose.isStateAvailable()).isFalse();
         TimeUnit.SECONDS.sleep(1);
         assertThat(awaitClose.isStateAvailable()).isFalse();
@@ -713,12 +713,12 @@ public class KafkaConsumerWrapperTest {
         mockConsumer.scheduleNopPollTask();
 
         // Run the consumer for at least 1 second
-        FutureStatus awaitClose = wrapper.startLoop(Executors.newSingleThreadExecutor(), false);
+        FutureStatus awaitClose = wrapper.startLoop(Executors.newSingleThreadExecutor());
         assertThat(awaitClose.isStateAvailable()).isFalse();
         TimeUnit.SECONDS.sleep(1);
 
         // Try to start the loop again and verify that the status has not changed
-        FutureStatus awaitClose2 = wrapper.startLoop(Executors.newSingleThreadExecutor(), false);
+        FutureStatus awaitClose2 = wrapper.startLoop(Executors.newSingleThreadExecutor());
         assertThat(awaitClose2).isSameInstanceAs(awaitClose);
 
         // Shutdown the wrapper to make the internal consumer wakeup and exit the loop
@@ -727,7 +727,7 @@ public class KafkaConsumerWrapperTest {
         assertThat(finalStatus.isShutdown()).isTrue();
 
         // Try to start the loop again and verify that the status is still SHUTDOWN
-        FutureStatus currentStatus = wrapper.startLoop(Executors.newSingleThreadExecutor(), false);
+        FutureStatus currentStatus = wrapper.startLoop(Executors.newSingleThreadExecutor());
         assertThat(currentStatus).isSameInstanceAs(finalStatus);
 
         assertThat(wrapper.shutdown()).isSameInstanceAs(finalStatus);
@@ -762,19 +762,16 @@ public class KafkaConsumerWrapperTest {
         assertThat(wrapper.getMonitor().isRunning()).isFalse();
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    public void shouldNotStartLoopDueToNotExistingTopic(boolean waitForInit) {
+    @Test
+    public void shouldNotStartLoopDueToNotExistingTopic() {
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         // Create a wrapper for a non-existing topic
         KafkaConsumerWrapper<String, String> wrapper =
                 makeWrapper(Collections.singleton("anotherTopic"), false);
 
-        FutureStatus status = wrapper.startLoop(executorService, waitForInit);
-        if (waitForInit) {
-            // If waitForInit is true, the status is immediately set to INIT_FAILED_BY_SUBSCRIPTION
-            assertThat(status.initFailed()).isTrue();
-        }
+        FutureStatus status = wrapper.startLoop(executorService);
+        // The status is immediately set to INIT_FAILED_BY_SUBSCRIPTION
+        assertThat(status.initFailed()).isTrue();
         assertThat(status.join()).isEqualTo(State.INIT_FAILED_BY_SUBSCRIPTION);
         assertThat(mockConsumer.subscription()).isEmpty();
         assertThat(mockConsumer.closed()).isTrue();
@@ -783,21 +780,19 @@ public class KafkaConsumerWrapperTest {
         assertThat(wrapper.getMonitor().isRunning()).isFalse();
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    public void shouldNotStartLoopDueToExceptionWhileCheckingExistingTopic(boolean waitForInit) {
+    @Test
+    public void shouldNotStartLoopDueToExceptionWhileCheckingExistingTopic() {
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         // Create a wrapper for a topic that exists but cannot be subscribed due to
         // an exception thrown while checking the topic's existence
         KafkaConsumerWrapper<String, String> wrapper =
                 makeWrapper(Collections.singleton("topic"), true);
 
-        FutureStatus status = wrapper.startLoop(executorService, waitForInit);
-        if (waitForInit) {
-            // If waitForInit is true, the status is immediately set to INIT_FAILED_BY_SUBSCRIPTION
-            assertThat(status.initFailed()).isTrue();
-        }
-        assertThat(status.join()).isEqualTo(State.INIT_FAILED_BY_SUBSCRIPTION);
+        FutureStatus status = wrapper.startLoop(executorService);
+
+        // The status is immediately set to INIT_FAILED_BY_EXCEPTION
+        assertThat(status.initFailed()).isTrue();
+        assertThat(status.join()).isEqualTo(State.INIT_FAILED_BY_EXCEPTION);
         assertThat(mockConsumer.subscription()).isEmpty();
         assertThat(mockConsumer.closed()).isTrue();
         assertThat(metadataListener.forcedUnsubscription()).isTrue();
@@ -805,19 +800,17 @@ public class KafkaConsumerWrapperTest {
         assertThat(wrapper.getMonitor().isRunning()).isFalse();
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    public void shouldNotStartLoopDueToPollExceptionWhileInitPolling(boolean waitForInit) {
+    @Test
+    public void shouldNotStartLoopDueToPollExceptionWhileInitPolling() {
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         KafkaConsumerWrapper<String, String> wrapper =
                 makeWrapper(Collections.singleton("topic"), false);
 
         mockConsumer.setPollException(new KafkaException("Fake Exception"));
-        FutureStatus status = wrapper.startLoop(executorService, waitForInit);
-        if (waitForInit) {
-            // If waitForInit is true, the status is immediately set to INIT_FAILED_BY_EXCEPTION
-            assertThat(status.initFailed()).isTrue();
-        }
+        FutureStatus status = wrapper.startLoop(executorService);
+
+        // The status is immediately set to INIT_FAILED_BY_EXCEPTION
+        assertThat(status.initFailed()).isTrue();
         assertThat(status.join()).isEqualTo(State.INIT_FAILED_BY_EXCEPTION);
         // Verify that the consumer has subscribed
         assertThat(mockConsumer.subscription()).containsExactly("topic");
@@ -828,19 +821,17 @@ public class KafkaConsumerWrapperTest {
         assertThat(wrapper.getMonitor().isRunning()).isFalse();
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    public void shouldNotStartLoopDueToOffsetExceptionWhileInitPolling(boolean waitForInit) {
+    @Test
+    public void shouldNotStartLoopDueToOffsetExceptionWhileInitPolling() {
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         KafkaConsumerWrapper<String, String> wrapper =
                 makeWrapper(Collections.singleton("topic"), false);
 
         mockConsumer.setOffsetsException(new KafkaException("Fake Exception"));
-        FutureStatus status = wrapper.startLoop(executorService, waitForInit);
-        if (waitForInit) {
-            // If waitForInit is true, the status is immediately set to INIT_FAILED_BY_EXCEPTION
-            assertThat(status.initFailed()).isTrue();
-        }
+        FutureStatus status = wrapper.startLoop(executorService);
+
+        // The status is immediately set to INIT_FAILED_BY_EXCEPTION
+        assertThat(status.initFailed()).isTrue();
         assertThat(status.join()).isEqualTo(State.INIT_FAILED_BY_EXCEPTION);
         // Verify that the consumer has subscribed
         assertThat(mockConsumer.subscription()).containsExactly("topic");
@@ -881,7 +872,7 @@ public class KafkaConsumerWrapperTest {
         mockConsumer.scheduleNopPollTask();
 
         // Run the consumer for at least 1 second
-        FutureStatus awaitClose = wrapper.startLoop(Executors.newSingleThreadExecutor(), false);
+        FutureStatus awaitClose = wrapper.startLoop(Executors.newSingleThreadExecutor());
         TimeUnit.SECONDS.sleep(1);
         assertThat(awaitClose.isStateAvailable()).isFalse();
         assertThat(wrapper.getMonitor().isRunning()).isTrue();
@@ -918,7 +909,7 @@ public class KafkaConsumerWrapperTest {
 
     @ParameterizedTest
     @MethodSource("deserializationModes")
-    void shouldConvertConsumerRecordsToKafkaRecords(
+    public void shouldConvertConsumerRecordsToKafkaRecords(
             String modeName,
             KafkaConsumerWrapper.RecordDeserializationMode<String, String> mode,
             DeserializationTiming expectedTiming) {


### PR DESCRIPTION
**Documentation**

- **CHANGELOG style**: Minor formatting improvements for consistency.

**Bug Fixes**

- **Subscribe/unsubscribe/subscribe race condition**: Fixed a race condition that could leave the connector in an inconsistent state when a client subscribed to an item, immediately unsubscribed, and then re-subscribed in quick succession. The Kafka consumer initialization is now completed synchronously and fully validated before any new subscription requests can trigger a new consumer creation. Additionally, cleanup on connection failure is now always executed correctly and in the right order, regardless of where the failure occurred.